### PR TITLE
fix: temporarily disable mfa_delete on secure buckets

### DIFF
--- a/modules/secure-bucket/main.tf
+++ b/modules/secure-bucket/main.tf
@@ -14,7 +14,10 @@ resource "aws_s3_bucket" "content" {
   }
 
   versioning = {
-    enabled    = true
-    mfa_delete = true
+    enabled = true
+
+    # Temporarily disabled due to Terraform issue.
+    # https://github.com/terraform-providers/terraform-provider-aws/issues/629
+    # mfa_delete = true
   }
 }


### PR DESCRIPTION
since mfa_delete can't be enabled via Terraform at this moment.
https://github.com/terraform-providers/terraform-provider-aws/issues/629