### PR TITLE
feat: enable AWS Config rules for monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ See [Benchmark Compliance](./compliance.md) to check which items in CIS benchmar
 - Set up IAM Password Policy.
 - Creates separated IAM roles for defining privileges and assigning them to entities such as IAM users and groups.
 - Creates an IAM role for contacting AWS support for incident handling.
+- Enable AWS Config rules to audit root account status.
 
 ### Logging & Monitoring
 
@@ -29,6 +30,7 @@ See [Benchmark Compliance](./compliance.md) to check which items in CIS benchmar
 ### Networking
 
 - Remove all rules associated with default route tables, default network ACLs and default security groups in the default VPC in all regions.
+- Enable AWS Config rules to audit unrestricted common ports in Security Group rules.
 - Enable VPC Flow Logs with the default VPC in all regions.
 - Enable GuardDuty in all regions.
 

--- a/compliance.md
+++ b/compliance.md
@@ -27,7 +27,7 @@ Implementation status for each item is categorized as follows.
 | 1.10 | Ensure IAM password policy prevents password reuse | OK | |
 | 1.11 | Ensure IAM password policy expires passwords within 90 days or less | OK | |
 | 1.12 | Ensure no root account access key exists | N/A | | |
-| 1.13 | Ensure MFA is enabled for the "root" account | N/A | |
+| 1.13 | Ensure MFA is enabled for the "root" account | OK | Although this module does not enforce the use of MFA, it enables a AWS Config rule to monitor that the MFA is enabled for root account. |
 | 1.14 | Ensure hardware MFA is enabled for the "root" account | N/A | |
 | 1.15 | Ensure security questions are registered in the AWS account | N/A | |
 | 1.16 | Ensure IAM policies are attached only to groups or roles | N/A | |
@@ -60,8 +60,8 @@ Implementation status for each item is categorized as follows.
 | 3.12 | Ensure a log metric filter and alarm exist for changes to network gateways | OK | |
 | 3.13 | Ensure a log metric filter and alarm exist for route table changes | OK | |
 | 3.14 | Ensure a log metric filter and alarm exist for VPC changes | OK | |
-| 4.1  | Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 | N/A | |
-| 4.2  | Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 | N/A | |
+| 4.1  | Ensure no security groups allow ingress from 0.0.0.0/0 to port 22 | OK | Monitored by the AWS Config rule. |
+| 4.2  | Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389 | OK | Monitored by the AWS Config rule. |
 | 4.3  | Ensure the default security group of every VPC restricts all traffic | OK | |
 | 4.4  | Ensure routing tables for VPC peering are "least access" | N/A | |
 

--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -258,3 +258,16 @@ module "config_baseline_us-west-2" {
     aws = "aws.us-west-2"
   }
 }
+
+# --------------------------------------------------------------------------------------------------
+# Global Config Rules
+# --------------------------------------------------------------------------------------------------
+
+resource "aws_config_config_rule" "root_mfa" {
+  name = "RootAccountMFAEnabled"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "ROOT_ACCOUNT_MFA_ENABLED"
+  }
+}

--- a/modules/config-baseline/main.tf
+++ b/modules/config-baseline/main.tf
@@ -33,3 +33,21 @@ resource "aws_config_configuration_recorder_status" "recorder" {
   is_enabled = true
   depends_on = ["aws_config_delivery_channel.bucket"]
 }
+
+resource "aws_config_config_rule" "restricted_ports" {
+  name = "RestrictedIncomingTraffic"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "RESTRICTED_INCOMING_TRAFFIC"
+  }
+
+  input_parameters = <<JSON
+{
+  "blockedPort1": "22",
+  "blockedPort2": "3389"
+}
+JSON
+
+  depends_on = ["aws_config_configuration_recorder.recorder"]
+}


### PR DESCRIPTION
It enables the following two rules.

- A rule to monitor the MFA setting of root account
- A rule to monitor unrestricted common port in Security Group
rules.