### PR TITLE
fix: create a global rule after recorders.

### DIFF
--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -270,4 +270,23 @@ resource "aws_config_config_rule" "root_mfa" {
     owner             = "AWS"
     source_identifier = "ROOT_ACCOUNT_MFA_ENABLED"
   }
+
+  # Ensure this rule is created after the configuration recorder.
+  depends_on = [
+    "module.config_baseline_ap-northeast-1",
+    "module.config_baseline_ap-northeast-2",
+    "module.config_baseline_ap-south-1",
+    "module.config_baseline_ap-southeast-1",
+    "module.config_baseline_ap-southeast-2",
+    "module.config_baseline_ca-central-1",
+    "module.config_baseline_eu-central-1",
+    "module.config_baseline_eu-west-1",
+    "module.config_baseline_eu-west-2",
+    "module.config_baseline_eu-west-3",
+    "module.config_baseline_sa-east-1",
+    "module.config_baseline_us-east-1",
+    "module.config_baseline_us-east-2",
+    "module.config_baseline_us-west-1",
+    "module.config_baseline_us-west-2",
+  ]
 }


### PR DESCRIPTION
aws_config_config_rule should be created after aws_config_configuration_recorder as stated below.
https://www.terraform.io/docs/providers/aws/r/config_config_rule.html