### PR TITLE
Allow setting logs retention in log groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This module is composed of several submodules and each of which can be used inde
 | vpc_iam_role_name | The name of the IAM Role which VPC Flow Logs will use. | string | `VPC-Flow-Logs-Publisher` | no |
 | vpc_iam_role_policy_name | The name of the IAM Role Policy which VPC Flow Logs will use. | string | `VPC-Flow-Logs-Publish-Policy` | no |
 | vpc_log_group_name | The name of CloudWatch Logs group to which VPC Flow Logs are delivered. | string | `default-vpc-flow-logs` | no |
+| vpc_log_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely. | string | `365` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This module is composed of several submodules and each of which can be used inde
 | cloudtrail_key_deletion_window_in_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days. | string | `10` | no |
 | cloudtrail_name | The name of the trail. | string | `cloudtrail-multi-region` | no |
 | cloudtrail_s3_key_prefix | The prefix used when CloudTrail delivers events to the S3 bucket. | string | `cloudtrail` | no |
-| cloudwatch_logs_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely. | string | `365` | no |
+| cloudwatch_logs_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely. | string | `365` | no |
 | config_delivery_frequency | The frequency which AWS Config sends a snapshot into the S3 bucket. | string | `One_Hour` | no |
 | config_iam_role_name | The name of the IAM Role which AWS Config will use. | string | `Config-Recorder` | no |
 | config_iam_role_policy_name | The name of the IAM Role Policy which AWS Config will use. | string | `Config-Recorder-Policy` | no |
@@ -125,7 +125,7 @@ This module is composed of several submodules and each of which can be used inde
 | vpc_iam_role_name | The name of the IAM Role which VPC Flow Logs will use. | string | `VPC-Flow-Logs-Publisher` | no |
 | vpc_iam_role_policy_name | The name of the IAM Role Policy which VPC Flow Logs will use. | string | `VPC-Flow-Logs-Publish-Policy` | no |
 | vpc_log_group_name | The name of CloudWatch Logs group to which VPC Flow Logs are delivered. | string | `default-vpc-flow-logs` | no |
-| vpc_log_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely. | string | `365` | no |
+| vpc_log_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely. | string | `365` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module "secure-baseline" {
 }
 ```
 
-Check [the example](./examples/root-example/regions.tf) to understand how these providers are defined. 
+Check [the example](./examples/root-example/regions.tf) to understand how these providers are defined.
 Note that you need to define a provider for each AWS region and pass them to the module. Currently this is the recommended way to handle multiple regions in one module.
 Detailed information can be found at [Providers within Modules - Terraform Docs].
 
@@ -101,6 +101,7 @@ This module is composed of several submodules and each of which can be used inde
 | cloudtrail_key_deletion_window_in_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days. | string | `10` | no |
 | cloudtrail_name | The name of the trail. | string | `cloudtrail-multi-region` | no |
 | cloudtrail_s3_key_prefix | The prefix used when CloudTrail delivers events to the S3 bucket. | string | `cloudtrail` | no |
+| cloudwatch_logs_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely. | string | `365` | no |
 | config_delivery_frequency | The frequency which AWS Config sends a snapshot into the S3 bucket. | string | `One_Hour` | no |
 | config_iam_role_name | The name of the IAM Role which AWS Config will use. | string | `Config-Recorder` | no |
 | config_iam_role_policy_name | The name of the IAM Role Policy which AWS Config will use. | string | `Config-Recorder-Policy` | no |

--- a/main.tf
+++ b/main.tf
@@ -96,15 +96,16 @@ module "iam_baseline" {
 module "cloudtrail_baseline" {
   source = "./modules/cloudtrail-baseline"
 
-  aws_account_id              = "${var.aws_account_id}"
-  cloudtrail_name             = "${var.cloudtrail_name}"
-  cloudwatch_logs_group_name  = "${var.cloudtrail_cloudwatch_logs_group_name}"
-  iam_role_name               = "${var.cloudtrail_iam_role_name}"
-  iam_role_policy_name        = "${var.cloudtrail_iam_role_policy_name}"
-  key_deletion_window_in_days = "${var.cloudtrail_key_deletion_window_in_days}"
-  region                      = "${var.region}"
-  s3_bucket_name              = "${module.audit_log_bucket.this_bucket_id}"
-  s3_key_prefix               = "${var.cloudtrail_s3_key_prefix}"
+  aws_account_id                    = "${var.aws_account_id}"
+  cloudtrail_name                   = "${var.cloudtrail_name}"
+  cloudwatch_logs_group_name        = "${var.cloudtrail_cloudwatch_logs_group_name}"
+  cloudwatch_logs_retention_in_days = "${var.cloudwatch_logs_retention_in_days}"
+  iam_role_name                     = "${var.cloudtrail_iam_role_name}"
+  iam_role_policy_name              = "${var.cloudtrail_iam_role_policy_name}"
+  key_deletion_window_in_days       = "${var.cloudtrail_key_deletion_window_in_days}"
+  region                            = "${var.region}"
+  s3_bucket_name                    = "${module.audit_log_bucket.this_bucket_id}"
+  s3_key_prefix                     = "${var.cloudtrail_s3_key_prefix}"
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/cloudtrail-baseline/README.md
+++ b/modules/cloudtrail-baseline/README.md
@@ -9,6 +9,7 @@ Enable CloudTrail in all regions and deliver events to CloudWatch Logs. CloudTra
 | aws_account_id | The AWS Account ID number of the account. | string | - | yes |
 | cloudtrail_name | The name of the trail. | string | `cloudtrail-multi-region` | no |
 | cloudwatch_logs_group_name | The name of CloudWatch Logs group to which CloudTrail events are delivered. | string | `cloudtrail-multi-region` | no |
+| cloudwatch_logs_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely. | string | `365` | no |
 | iam_role_name | The name of the IAM Role to be used by CloudTrail to delivery logs to CloudWatch Logs group. | string | `CloudTrail-CloudWatch-Delivery-Role` | no |
 | iam_role_policy_name | The name of the IAM Role Policy to be used by CloudTrail to delivery logs to CloudWatch Logs group. | string | `CloudTrail-CloudWatch-Delivery-Policy` | no |
 | key_deletion_window_in_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days. | string | `10` | no |

--- a/modules/cloudtrail-baseline/README.md
+++ b/modules/cloudtrail-baseline/README.md
@@ -9,7 +9,7 @@ Enable CloudTrail in all regions and deliver events to CloudWatch Logs. CloudTra
 | aws_account_id | The AWS Account ID number of the account. | string | - | yes |
 | cloudtrail_name | The name of the trail. | string | `cloudtrail-multi-region` | no |
 | cloudwatch_logs_group_name | The name of CloudWatch Logs group to which CloudTrail events are delivered. | string | `cloudtrail-multi-region` | no |
-| cloudwatch_logs_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely. | string | `365` | no |
+| cloudwatch_logs_retention_in_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely. | string | `365` | no |
 | iam_role_name | The name of the IAM Role to be used by CloudTrail to delivery logs to CloudWatch Logs group. | string | `CloudTrail-CloudWatch-Delivery-Role` | no |
 | iam_role_policy_name | The name of the IAM Role Policy to be used by CloudTrail to delivery logs to CloudWatch Logs group. | string | `CloudTrail-CloudWatch-Delivery-Policy` | no |
 | key_deletion_window_in_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days. | string | `10` | no |

--- a/modules/cloudtrail-baseline/main.tf
+++ b/modules/cloudtrail-baseline/main.tf
@@ -3,7 +3,8 @@
 # --------------------------------------------------------------------------------------------------
 
 resource "aws_cloudwatch_log_group" "cloudtrail_events" {
-  name = "${var.cloudwatch_logs_group_name}"
+  name              = "${var.cloudwatch_logs_group_name}"
+  retention_in_days = "${var.cloudwatch_logs_retention_in_days}"
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/cloudtrail-baseline/variables.tf
+++ b/modules/cloudtrail-baseline/variables.tf
@@ -13,7 +13,7 @@ variable "cloudwatch_logs_group_name" {
 }
 
 variable "cloudwatch_logs_retention_in_days" {
-  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely."
+  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
   default     = 365
 }
 

--- a/modules/cloudtrail-baseline/variables.tf
+++ b/modules/cloudtrail-baseline/variables.tf
@@ -12,6 +12,11 @@ variable "cloudwatch_logs_group_name" {
   default     = "cloudtrail-multi-region"
 }
 
+variable "cloudwatch_logs_retention_in_days" {
+  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely."
+  default     = 365
+}
+
 variable "iam_role_name" {
   description = "The name of the IAM Role to be used by CloudTrail to delivery logs to CloudWatch Logs group."
   default     = "CloudTrail-CloudWatch-Delivery-Role"

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,11 @@ variable "cloudtrail_cloudwatch_logs_group_name" {
   default     = "cloudtrail-multi-region"
 }
 
+variable "cloudwatch_logs_retention_in_days" {
+  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely."
+  default     = 365
+}
+
 variable "cloudtrail_iam_role_name" {
   description = "The name of the IAM Role to be used by CloudTrail to delivery logs to CloudWatch Logs group."
   default     = "CloudTrail-CloudWatch-Delivery-Role"

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,11 @@ variable "vpc_log_group_name" {
   default     = "default-vpc-flow-logs"
 }
 
+variable "vpc_log_retention_in_days" {
+  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely."
+  default     = 365
+}
+
 # --------------------------------------------------------------------------------------------------
 # Variables for config-baseline module.
 # --------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -116,7 +116,7 @@ variable "vpc_log_group_name" {
 }
 
 variable "vpc_log_retention_in_days" {
-  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely."
+  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
   default     = 365
 }
 
@@ -159,7 +159,7 @@ variable "cloudtrail_cloudwatch_logs_group_name" {
 }
 
 variable "cloudwatch_logs_retention_in_days" {
-  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to `null` in Terraform > 0.12 to keep logs indefinitely."
+  description = "Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely."
   default     = 365
 }
 

--- a/vpc_baselines.tf
+++ b/vpc_baselines.tf
@@ -48,7 +48,8 @@ END_OF_POLICY
 }
 
 resource "aws_cloudwatch_log_group" "default_vpc_flow_logs" {
-  name = "${var.vpc_log_group_name}"
+  name              = "${var.vpc_log_group_name}"
+  retention_in_days = "${var.vpc_log_rentention_in_days}"
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/vpc_baselines.tf
+++ b/vpc_baselines.tf
@@ -49,7 +49,7 @@ END_OF_POLICY
 
 resource "aws_cloudwatch_log_group" "default_vpc_flow_logs" {
   name              = "${var.vpc_log_group_name}"
-  retention_in_days = "${var.vpc_log_rentention_in_days}"
+  retention_in_days = "${var.vpc_log_retention_in_days}"
 }
 
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
To reduce costs.

- VPC Logs can be manually archived to S3 if needed
- Cloudtrail logs are already mirrored to S3
