### PR TITLE
change from log_group_name to log_destination

### DIFF
--- a/modules/vpc-baseline/README.md
+++ b/modules/vpc-baseline/README.md
@@ -9,7 +9,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| vpc_flow_logs_group_name | The name of the CloudWatch Logs group to which VPC Flow Logs will be written. | string | - | yes |
+| vpc_flow_logs_group_arn | The arn of the CloudWatch Logs group to which VPC Flow Logs will be written. | string | - | yes |
 | vpc_flow_logs_iam_role_arn | The ARN of the IAM Role which will be used by VPC Flow Logs. | string | - | yes |
 
 ## Outputs

--- a/modules/vpc-baseline/main.tf
+++ b/modules/vpc-baseline/main.tf
@@ -52,7 +52,7 @@ resource "aws_default_security_group" "default" {
 # --------------------------------------------------------------------------------------------------
 
 resource "aws_flow_log" "default_vpc_flow_logs" {
-  log_group_name = "${var.vpc_flow_logs_group_name}"
+  log_destination = "${var.vpc_flow_logs_group_arn}"
   iam_role_arn   = "${var.vpc_flow_logs_iam_role_arn}"
   vpc_id         = "${aws_default_vpc.default.id}"
   traffic_type   = "ALL"

--- a/modules/vpc-baseline/main.tf
+++ b/modules/vpc-baseline/main.tf
@@ -53,7 +53,7 @@ resource "aws_default_security_group" "default" {
 
 resource "aws_flow_log" "default_vpc_flow_logs" {
   log_destination = "${var.vpc_flow_logs_group_arn}"
-  iam_role_arn   = "${var.vpc_flow_logs_iam_role_arn}"
-  vpc_id         = "${aws_default_vpc.default.id}"
-  traffic_type   = "ALL"
+  iam_role_arn    = "${var.vpc_flow_logs_iam_role_arn}"
+  vpc_id          = "${aws_default_vpc.default.id}"
+  traffic_type    = "ALL"
 }

--- a/modules/vpc-baseline/variables.tf
+++ b/modules/vpc-baseline/variables.tf
@@ -1,5 +1,5 @@
-variable "vpc_flow_logs_group_name" {
-  description = "The name of the CloudWatch Logs group to which VPC Flow Logs will be written."
+variable "vpc_flow_logs_group_arn" {
+  description = "The arn of the CloudWatch Logs group to which VPC Flow Logs will be written."
 }
 
 variable "vpc_flow_logs_iam_role_arn" {

--- a/vpc_baselines.tf
+++ b/vpc_baselines.tf
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_log_group" "default_vpc_flow_logs" {
 
 module "vpc_baseline_ap-northeast-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -69,7 +69,7 @@ module "vpc_baseline_ap-northeast-1" {
 
 module "vpc_baseline_ap-northeast-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -79,7 +79,7 @@ module "vpc_baseline_ap-northeast-2" {
 
 module "vpc_baseline_ap-south-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -89,7 +89,7 @@ module "vpc_baseline_ap-south-1" {
 
 module "vpc_baseline_ap-southeast-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -99,7 +99,7 @@ module "vpc_baseline_ap-southeast-1" {
 
 module "vpc_baseline_ap-southeast-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -109,7 +109,7 @@ module "vpc_baseline_ap-southeast-2" {
 
 module "vpc_baseline_ca-central-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -119,7 +119,7 @@ module "vpc_baseline_ca-central-1" {
 
 module "vpc_baseline_eu-central-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -129,7 +129,7 @@ module "vpc_baseline_eu-central-1" {
 
 module "vpc_baseline_eu-west-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -139,7 +139,7 @@ module "vpc_baseline_eu-west-1" {
 
 module "vpc_baseline_eu-west-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -149,7 +149,7 @@ module "vpc_baseline_eu-west-2" {
 
 module "vpc_baseline_eu-west-3" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -159,7 +159,7 @@ module "vpc_baseline_eu-west-3" {
 
 module "vpc_baseline_sa-east-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -169,7 +169,7 @@ module "vpc_baseline_sa-east-1" {
 
 module "vpc_baseline_us-east-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -179,7 +179,7 @@ module "vpc_baseline_us-east-1" {
 
 module "vpc_baseline_us-east-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -189,7 +189,7 @@ module "vpc_baseline_us-east-2" {
 
 module "vpc_baseline_us-west-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -199,7 +199,7 @@ module "vpc_baseline_us-west-1" {
 
 module "vpc_baseline_us-west-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
+  vpc_flow_logs_group_arn    = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {

--- a/vpc_baselines.tf
+++ b/vpc_baselines.tf
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_log_group" "default_vpc_flow_logs" {
 
 module "vpc_baseline_ap-northeast-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -69,7 +69,7 @@ module "vpc_baseline_ap-northeast-1" {
 
 module "vpc_baseline_ap-northeast-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -79,7 +79,7 @@ module "vpc_baseline_ap-northeast-2" {
 
 module "vpc_baseline_ap-south-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -89,7 +89,7 @@ module "vpc_baseline_ap-south-1" {
 
 module "vpc_baseline_ap-southeast-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -99,7 +99,7 @@ module "vpc_baseline_ap-southeast-1" {
 
 module "vpc_baseline_ap-southeast-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -109,7 +109,7 @@ module "vpc_baseline_ap-southeast-2" {
 
 module "vpc_baseline_ca-central-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -119,7 +119,7 @@ module "vpc_baseline_ca-central-1" {
 
 module "vpc_baseline_eu-central-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -129,7 +129,7 @@ module "vpc_baseline_eu-central-1" {
 
 module "vpc_baseline_eu-west-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -139,7 +139,7 @@ module "vpc_baseline_eu-west-1" {
 
 module "vpc_baseline_eu-west-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -149,7 +149,7 @@ module "vpc_baseline_eu-west-2" {
 
 module "vpc_baseline_eu-west-3" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -159,7 +159,7 @@ module "vpc_baseline_eu-west-3" {
 
 module "vpc_baseline_sa-east-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -169,7 +169,7 @@ module "vpc_baseline_sa-east-1" {
 
 module "vpc_baseline_us-east-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -179,7 +179,7 @@ module "vpc_baseline_us-east-1" {
 
 module "vpc_baseline_us-east-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -189,7 +189,7 @@ module "vpc_baseline_us-east-2" {
 
 module "vpc_baseline_us-west-1" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {
@@ -199,7 +199,7 @@ module "vpc_baseline_us-west-1" {
 
 module "vpc_baseline_us-west-2" {
   source                     = "./modules/vpc-baseline"
-  vpc_flow_logs_group_name   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.name}"
+  vpc_flow_logs_group_arn   = "${aws_cloudwatch_log_group.default_vpc_flow_logs.arn}"
   vpc_flow_logs_iam_role_arn = "${aws_iam_role.vpc_flow_logs_publisher.arn}"
 
   providers = {


### PR DESCRIPTION
log_group_name has been deprecated so I replaced them all with log_destination and updated the calling modules and variables as required.