### PR TITLE
Change alarm status breach status

### DIFF
--- a/modules/alarm-baseline/main.tf
+++ b/modules/alarm-baseline/main.tf
@@ -33,6 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   threshold                 = "1"
   alarm_description         = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -59,6 +60,7 @@ resource "aws_cloudwatch_metric_alarm" "no_mfa_console_signin" {
   threshold                 = "1"
   alarm_description         = "Monitoring for single-factor console logins will increase visibility into accounts that are not protected by MFA."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -85,6 +87,7 @@ resource "aws_cloudwatch_metric_alarm" "root_usage" {
   threshold                 = "1"
   alarm_description         = "Monitoring for root account logins will provide visibility into the use of a fully privileged account and an opportunity to reduce the use of it."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -111,6 +114,7 @@ resource "aws_cloudwatch_metric_alarm" "iam_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to IAM policies will help ensure authentication and authorization controls remain intact."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -137,6 +141,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudtrail_cfg_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to CloudTrail's configuration will help ensure sustained visibility to activities performed in the AWS account."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -163,6 +168,7 @@ resource "aws_cloudwatch_metric_alarm" "console_signin_failures" {
   threshold                 = "1"
   alarm_description         = "Monitoring failed console logins may decrease lead time to detect an attempt to brute force a credential, which may provide an indicator, such as source IP, that can be used in other event correlation."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -189,6 +195,7 @@ resource "aws_cloudwatch_metric_alarm" "disable_or_delete_cmk" {
   threshold                 = "1"
   alarm_description         = "Monitoring failed console logins may decrease lead time to detect an attempt to brute force a credential, which may provide an indicator, such as source IP, that can be used in other event correlation."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -215,6 +222,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_bucket_policy_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to S3 bucket policies may reduce time to detect and correct permissive policies on sensitive S3 buckets."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -241,6 +249,7 @@ resource "aws_cloudwatch_metric_alarm" "aws_config_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to AWS Config configuration will help ensure sustained visibility of configuration items within the AWS account."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -267,6 +276,7 @@ resource "aws_cloudwatch_metric_alarm" "security_group_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to security group will help ensure that resources and services are not unintentionally exposed."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -293,6 +303,7 @@ resource "aws_cloudwatch_metric_alarm" "nacl_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to NACLs will help ensure that AWS resources and services are not unintentionally exposed."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -319,6 +330,7 @@ resource "aws_cloudwatch_metric_alarm" "network_gw_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to network gateways will help ensure that all ingress/egress traffic traverses the VPC border via a controlled path."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -345,6 +357,7 @@ resource "aws_cloudwatch_metric_alarm" "route_table_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to route tables will help ensure that all VPC traffic flows through an expected path."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }
 
@@ -371,5 +384,6 @@ resource "aws_cloudwatch_metric_alarm" "vpc_changes" {
   threshold                 = "1"
   alarm_description         = "Monitoring changes to VPC will help ensure that all VPC traffic flows through an expected path."
   alarm_actions             = ["${aws_sns_topic.alarms.arn}"]
+  treat_missing_data        = "notBreaching"
   insufficient_data_actions = []
 }


### PR DESCRIPTION
Adding all these alarms leaves them in unknown status if there is no status read out when missing (Config rules don't fire all the time, only on event). It's better to just have them on 'good' rather than breaching, no? It defaults to missing.

Adding `treat_missing_data` to the aws_cloudwatch_metric_alarm resolves this as per this MR.

https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html#treat_missing_data