### PR TITLE
feat: add a flag to enable force_destroy on S3 buckets

### DIFF
--- a/examples/root-example/variables.tf
+++ b/examples/root-example/variables.tf
@@ -6,7 +6,6 @@ variable "secret_key" {
 
 variable "audit_s3_bucket_name" {
   description = "The name of the S3 bucket to store various audit logs."
-  default     = "YOUR_BUCKET_NAME_HERE"
 }
 
 variable "support_iam_role_principal_arn" {

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ module "audit_log_bucket" {
   bucket_name                       = var.audit_log_bucket_name
   log_bucket_name                   = "${var.audit_log_bucket_name}-access-logs"
   lifecycle_glacier_transition_days = var.audit_log_lifecycle_glacier_transition_days
+  force_destroy                     = var.audit_log_bucket_force_destroy
 }
 
 resource "aws_s3_bucket_policy" "audit_log_bucket_policy" {

--- a/modules/secure-bucket/main.tf
+++ b/modules/secure-bucket/main.tf
@@ -1,7 +1,9 @@
 resource "aws_s3_bucket" "access_log" {
   bucket = var.log_bucket_name
 
-  acl = "log-delivery-write"
+  acl           = "log-delivery-write"
+  force_destroy = var.force_destroy
+
 
   lifecycle_rule {
     id      = "auto-archive"
@@ -28,7 +30,8 @@ resource "aws_s3_bucket_public_access_block" "access_log" {
 resource "aws_s3_bucket" "content" {
   bucket = var.bucket_name
 
-  acl = "private"
+  acl           = "private"
+  force_destroy = var.force_destroy
 
   logging {
     target_bucket = aws_s3_bucket.access_log.id

--- a/modules/secure-bucket/variables.tf
+++ b/modules/secure-bucket/variables.tf
@@ -9,3 +9,7 @@ variable "lifecycle_glacier_transition_days" {
   default     = 90
 }
 
+variable "force_destroy" {
+  description = " A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,11 @@ variable "audit_log_lifecycle_glacier_transition_days" {
   default     = 90
 }
 
+variable "audit_log_bucket_force_destroy" {
+  description = " A boolean that indicates all objects should be deleted from the audit log bucket so that the bucket can be destroyed without error. These objects are not recoverable."
+  default     = false
+}
+
 variable "region" {
   description = "The AWS region in which global resources are set up."
 }


### PR DESCRIPTION
force_destroy flag defaults to false since the accidental deletion of audit logs might be
unacceptable in highly secured environments.
fixes #48