### PR TITLE
fix: do not read AWS Organization when account_type is set to "individual"

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -37,7 +37,9 @@ module "audit_log_bucket" {
   tags = var.tags
 }
 
-data "aws_organizations_organization" "org" {}
+data "aws_organizations_organization" "org" {
+  count = local.is_individual_account ? 0 : 1
+}
 
 data "aws_iam_policy_document" "audit_log" {
   count = local.use_external_bucket ? 0 : 1
@@ -89,7 +91,7 @@ data "aws_iam_policy_document" "audit_log" {
     }
     resources = concat(
       ["${module.audit_log_bucket.this_bucket.arn}/cloudtrail/AWSLogs/${var.aws_account_id}/*"],
-      local.is_master_account ? ["${module.audit_log_bucket.this_bucket.arn}/cloudtrail/AWSLogs/${data.aws_organizations_organization.org.id}/*"] : []
+      local.is_master_account ? ["${module.audit_log_bucket.this_bucket.arn}/cloudtrail/AWSLogs/${data.aws_organizations_organization.org[0].id}/*"] : []
     )
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
refs #70 