### PR TITLE
Enable bucket server side encryption for local buckets

### DIFF
--- a/modules/secure-bucket/main.tf
+++ b/modules/secure-bucket/main.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "access_log" {
 
   bucket = var.log_bucket_name
 
-  acl           = "log-delivery-write"
+  acl = "log-delivery-write"
 
   server_side_encryption_configuration {
     rule {


### PR DESCRIPTION
Default secure-bucket module to `sse_algorithm = "AES256"`

fixes nozaq/terraform-aws-secure-baseline/issues/77