### PR TITLE
Output sns topic where cloudtrail publishes events

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ module "cloudtrail_baseline" {
   enabled                           = local.is_cloudtrail_enabled
   aws_account_id                    = var.aws_account_id
   cloudtrail_name                   = var.cloudtrail_name
+  cloudtrail_sns_topic_name         = var.cloudtrail_sns_topic_name
   cloudwatch_logs_group_name        = var.cloudtrail_cloudwatch_logs_group_name
   cloudwatch_logs_retention_in_days = var.cloudwatch_logs_retention_in_days
   iam_role_name                     = var.cloudtrail_iam_role_name

--- a/modules/cloudtrail-baseline/outputs.tf
+++ b/modules/cloudtrail-baseline/outputs.tf
@@ -3,6 +3,11 @@ output "cloudtrail" {
   value       = var.enabled ? aws_cloudtrail.global[0] : null
 }
 
+output "cloudtrail_sns_topic" {
+  description = "The sns topic linked to the cloudtrail."
+  value       = var.enabled ? aws_sns_topic.cloudtrail-sns-topic[0] : null
+}
+
 output "kms_key" {
   description = "The  KMS key used for encrypting CloudTrail events."
   value       = var.enabled ? aws_kms_key.cloudtrail[0] : null

--- a/modules/cloudtrail-baseline/variables.tf
+++ b/modules/cloudtrail-baseline/variables.tf
@@ -12,6 +12,11 @@ variable "cloudtrail_name" {
   default     = "cloudtrail-multi-region"
 }
 
+variable "cloudtrail_sns_topic_name" {
+  description = "The sns topic linked to the cloudtrail"
+  default     = "cloudtrail-multi-region-sns-topic"
+}
+
 variable "cloudwatch_logs_group_name" {
   description = "The name of CloudWatch Logs group to which CloudTrail events are delivered."
   default     = "cloudtrail-multi-region"

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,11 @@ output "cloudtrail" {
   value       = module.cloudtrail_baseline.cloudtrail
 }
 
+output "cloudtrail_sns_topic" {
+  description = "The sns topic linked to the cloudtrail."
+  value       = module.cloudtrail_baseline.cloudtrail_sns_topic
+}
+
 output "cloudtrail_kms_key" {
   description = "The KMS key used for encrypting CloudTrail events."
   value       = module.cloudtrail_baseline.kms_key

--- a/variables.tf
+++ b/variables.tf
@@ -252,6 +252,11 @@ variable "cloudtrail_name" {
   default     = "cloudtrail-multi-region"
 }
 
+variable "cloudtrail_sns_topic_name" {
+  description = "The name of the sns topic to link to the trail."
+  default     = "cloudtrail-multi-region-sns-topic"
+}
+
 variable "cloudtrail_s3_key_prefix" {
   description = "The prefix used when CloudTrail delivers events to the S3 bucket."
   default     = "cloudtrail"


### PR DESCRIPTION
This creates and outputs an sns topic attached to the cloudtrail so that it could be used to feed the trail into a queue.
That would allow the trail to be integrated with external logging tools that need to fetch events from an sqs queue (in our case we use this to create an sqs for our graylog server).
It does not affect any of the existing modules functionality.

Please let me know if more clarification is needed for the purpose of this PR. :))