### PR TITLE
Allows attaching custom policy to the audit logs bucket

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -44,6 +44,8 @@ data "aws_organizations_organization" "org" {
 data "aws_iam_policy_document" "audit_log" {
   count = local.use_external_bucket ? 0 : 1
 
+  override_json = var.audit_log_bucket_custom_policy_json
+
   statement {
     sid     = "AWSCloudTrailAclCheckForConfig"
     actions = ["s3:GetBucketAcl"]

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,11 @@ variable "audit_log_bucket_name" {
   description = "The name of the S3 bucket to store various audit logs."
 }
 
+variable "audit_log_bucket_custom_policy_json" {
+  description = "Override policy for the audit log bucket. Allows addition of extra policies."
+  default     = "{}"
+}
+
 variable "audit_log_lifecycle_glacier_transition_days" {
   description = "The number of days after log creation when the log file is archived into Glacier."
   default     = 90


### PR DESCRIPTION
For example if you have roles in other AWS Accounts you want to grant
access to the logs