### PR TITLE
Make delivery of CloudTrail to CloudWatch Logs and SNS optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,14 @@ This module is composed of several submodules and each of which can be used inde
 | audit\_log\_bucket\_name | The name of the S3 bucket to store various audit logs. | `any` | n/a | yes |
 | audit\_log\_lifecycle\_glacier\_transition\_days | The number of days after log creation when the log file is archived into Glacier. | `number` | `90` | no |
 | aws\_account\_id | The AWS Account ID number of the account. | `any` | n/a | yes |
+| cloudtrail\_cloudwatch\_logs\_enabled | Specifies whether the trail is delivered to CloudWatch Logs. | `bool` | `true` | no |
 | cloudtrail\_cloudwatch\_logs\_group\_name | The name of CloudWatch Logs group to which CloudTrail events are delivered. | `string` | `"cloudtrail-multi-region"` | no |
 | cloudtrail\_iam\_role\_name | The name of the IAM Role to be used by CloudTrail to delivery logs to CloudWatch Logs group. | `string` | `"CloudTrail-CloudWatch-Delivery-Role"` | no |
 | cloudtrail\_iam\_role\_policy\_name | The name of the IAM Role Policy to be used by CloudTrail to delivery logs to CloudWatch Logs group. | `string` | `"CloudTrail-CloudWatch-Delivery-Policy"` | no |
 | cloudtrail\_key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days. | `number` | `10` | no |
 | cloudtrail\_name | The name of the trail. | `string` | `"cloudtrail-multi-region"` | no |
 | cloudtrail\_s3\_key\_prefix | The prefix used when CloudTrail delivers events to the S3 bucket. | `string` | `"cloudtrail"` | no |
+| cloudtrail\_sns\_topic\_enabled | Specifies whether the trail is delivered to a SNS topic. | `bool` | `true` | no |
 | cloudtrail\_sns\_topic\_name | The name of the sns topic to link to the trail. | `string` | `"cloudtrail-multi-region-sns-topic"` | no |
 | cloudwatch\_logs\_retention\_in\_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely. | `number` | `365` | no |
 | config\_aggregator\_name | The name of the organizational AWS Config Configuration Aggregator. | `string` | `"organization-aggregator"` | no |

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,9 @@ module "cloudtrail_baseline" {
   aws_account_id                    = var.aws_account_id
   cloudtrail_depends_on             = [aws_s3_bucket_policy.audit_log]
   cloudtrail_name                   = var.cloudtrail_name
+  cloudtrail_sns_topic_enabled      = var.cloudtrail_sns_topic_enabled
   cloudtrail_sns_topic_name         = var.cloudtrail_sns_topic_name
+  cloudwatch_logs_enabled           = var.cloudtrail_cloudwatch_logs_enabled
   cloudwatch_logs_group_name        = var.cloudtrail_cloudwatch_logs_group_name
   cloudwatch_logs_retention_in_days = var.cloudwatch_logs_retention_in_days
   iam_role_name                     = var.cloudtrail_iam_role_name

--- a/modules/cloudtrail-baseline/README.md
+++ b/modules/cloudtrail-baseline/README.md
@@ -22,7 +22,9 @@ Enable CloudTrail in all regions and deliver events to CloudWatch Logs. CloudTra
 | aws\_account\_id | The AWS Account ID number of the account. | `any` | n/a | yes |
 | cloudtrail\_depends\_on | External resources which should be set up before CloudTrail. | `list` | `[]` | no |
 | cloudtrail\_name | The name of the trail. | `string` | `"cloudtrail-multi-region"` | no |
+| cloudtrail\_sns\_topic\_enabled | Specifies whether the trail is delivered to a SNS topic. | `bool` | `true` | no |
 | cloudtrail\_sns\_topic\_name | The sns topic linked to the cloudtrail | `string` | `"cloudtrail-multi-region-sns-topic"` | no |
+| cloudwatch\_logs\_enabled | Specifies whether the trail is delivered to CloudWatch Logs. | `bool` | `true` | no |
 | cloudwatch\_logs\_group\_name | The name of CloudWatch Logs group to which CloudTrail events are delivered. | `string` | `"cloudtrail-multi-region"` | no |
 | cloudwatch\_logs\_retention\_in\_days | Number of days to retain logs for. CIS recommends 365 days.  Possible values are: 0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, and 3653. Set to 0 to keep logs indefinitely. | `number` | `365` | no |
 | enabled | The boolean flag whether this module is enabled or not. No resources are created when set to false. | `bool` | `true` | no |

--- a/modules/cloudtrail-baseline/main.tf
+++ b/modules/cloudtrail-baseline/main.tf
@@ -2,7 +2,7 @@
 # CloudWatch Logs group to accept CloudTrail event stream.
 # --------------------------------------------------------------------------------------------------
 resource "aws_cloudwatch_log_group" "cloudtrail_events" {
-  count = var.enabled ? 1 : 0
+  count = var.cloudwatch_logs_enabled && var.enabled ? 1 : 0
 
   name              = var.cloudwatch_logs_group_name
   retention_in_days = var.cloudwatch_logs_retention_in_days
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "cloudwatch_delivery_assume_policy" {
 }
 
 resource "aws_iam_role" "cloudwatch_delivery" {
-  count = var.enabled ? 1 : 0
+  count = var.cloudwatch_logs_enabled && var.enabled ? 1 : 0
 
   name               = var.iam_role_name
   assume_role_policy = data.aws_iam_policy_document.cloudwatch_delivery_assume_policy.json
@@ -35,7 +35,7 @@ resource "aws_iam_role" "cloudwatch_delivery" {
 }
 
 data "aws_iam_policy_document" "cloudwatch_delivery_policy" {
-  count = var.enabled ? 1 : 0
+  count = var.cloudwatch_logs_enabled && var.enabled ? 1 : 0
 
   statement {
     sid       = "AWSCloudTrailCreateLogStream2014110"
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "cloudwatch_delivery_policy" {
 }
 
 resource "aws_iam_role_policy" "cloudwatch_delivery_policy" {
-  count = var.enabled ? 1 : 0
+  count = var.cloudwatch_logs_enabled && var.enabled ? 1 : 0
 
   name = var.iam_role_policy_name
   role = aws_iam_role.cloudwatch_delivery[0].id
@@ -61,7 +61,7 @@ resource "aws_iam_role_policy" "cloudwatch_delivery_policy" {
 
 # --------------------------------------------------------------------------------------------------
 # KMS Key to encrypt CloudTrail events.
-# The policy was derived from the default key policy descrived in AWS CloudTrail User Guide.
+# The policy was derived from the default key policy described in AWS CloudTrail User Guide.
 # https://docs.aws.amazon.com/awscloudtrail/latest/userguide/default-cmk-policy.html
 # --------------------------------------------------------------------------------------------------
 data "aws_iam_policy_document" "cloudtrail_key_policy" {
@@ -204,14 +204,14 @@ resource "aws_kms_key" "cloudtrail" {
 # --------------------------------------------------------------------------------------------------
 
 resource "aws_sns_topic" "cloudtrail-sns-topic" {
-  count = var.enabled ? 1 : 0
+  count = var.cloudtrail_sns_topic_enabled && var.enabled ? 1 : 0
 
   name              = var.cloudtrail_sns_topic_name
   kms_master_key_id = aws_kms_key.cloudtrail[0].id
 }
 
 data "aws_iam_policy_document" "cloudtrail-sns-policy" {
-  count = var.enabled ? 1 : 0
+  count = var.cloudtrail_sns_topic_enabled && var.enabled ? 1 : 0
 
   statement {
     actions   = ["sns:Publish"]
@@ -225,7 +225,7 @@ data "aws_iam_policy_document" "cloudtrail-sns-policy" {
 }
 
 resource "aws_sns_topic_policy" "local-account-cloudtrail" {
-  count = var.enabled ? 1 : 0
+  count = var.cloudtrail_sns_topic_enabled && var.enabled ? 1 : 0
 
   arn    = aws_sns_topic.cloudtrail-sns-topic[0].arn
   policy = data.aws_iam_policy_document.cloudtrail-sns-policy[0].json
@@ -240,8 +240,8 @@ resource "aws_cloudtrail" "global" {
 
   name = var.cloudtrail_name
 
-  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.cloudtrail_events[0].arn
-  cloud_watch_logs_role_arn     = aws_iam_role.cloudwatch_delivery[0].arn
+  cloud_watch_logs_group_arn    = var.cloudwatch_logs_enabled ? aws_cloudwatch_log_group.cloudtrail_events[0].arn : null
+  cloud_watch_logs_role_arn     = var.cloudwatch_logs_enabled ? aws_iam_role.cloudwatch_delivery[0].arn : null
   enable_log_file_validation    = true
   include_global_service_events = true
   is_multi_region_trail         = true
@@ -249,7 +249,7 @@ resource "aws_cloudtrail" "global" {
   kms_key_id                    = aws_kms_key.cloudtrail[0].arn
   s3_bucket_name                = var.s3_bucket_name
   s3_key_prefix                 = var.s3_key_prefix
-  sns_topic_name                = aws_sns_topic.cloudtrail-sns-topic[0].arn
+  sns_topic_name                = var.cloudtrail_sns_topic_enabled ? aws_sns_topic.cloudtrail-sns-topic[0].arn : null
 
   tags = var.tags
 

--- a/modules/cloudtrail-baseline/outputs.tf
+++ b/modules/cloudtrail-baseline/outputs.tf
@@ -5,7 +5,7 @@ output "cloudtrail" {
 
 output "cloudtrail_sns_topic" {
   description = "The sns topic linked to the cloudtrail."
-  value       = var.enabled ? aws_sns_topic.cloudtrail-sns-topic[0] : null
+  value       = var.cloudtrail_sns_topic_enabled && var.enabled ? aws_sns_topic.cloudtrail-sns-topic[0] : null
 }
 
 output "kms_key" {
@@ -15,10 +15,10 @@ output "kms_key" {
 
 output "log_delivery_iam_role" {
   description = "The IAM role used for delivering CloudTrail events to CloudWatch Logs."
-  value       = var.enabled ? aws_iam_role.cloudwatch_delivery[0] : null
+  value       = var.cloudwatch_logs_enabled && var.enabled ? aws_iam_role.cloudwatch_delivery[0] : null
 }
 
 output "log_group" {
   description = "The CloudWatch Logs log group which stores CloudTrail events."
-  value       = var.enabled ? aws_cloudwatch_log_group.cloudtrail_events[0] : null
+  value       = var.cloudwatch_logs_enabled && var.enabled ? aws_cloudwatch_log_group.cloudtrail_events[0] : null
 }

--- a/modules/cloudtrail-baseline/variables.tf
+++ b/modules/cloudtrail-baseline/variables.tf
@@ -12,9 +12,19 @@ variable "cloudtrail_name" {
   default     = "cloudtrail-multi-region"
 }
 
+variable "cloudtrail_sns_topic_enabled" {
+  description = "Specifies whether the trail is delivered to a SNS topic."
+  default     = true
+}
+
 variable "cloudtrail_sns_topic_name" {
-  description = "The sns topic linked to the cloudtrail"
+  description = "The SNS topic linked to the CloudTrail"
   default     = "cloudtrail-multi-region-sns-topic"
+}
+
+variable "cloudwatch_logs_enabled" {
+  description = "Specifies whether the trail is delivered to CloudWatch Logs."
+  default     = true
 }
 
 variable "cloudwatch_logs_group_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -228,6 +228,11 @@ variable "config_aggregator_name_prefix" {
 # Variables for cloudtrail-baseline module.
 # --------------------------------------------------------------------------------------------------
 
+variable "cloudtrail_cloudwatch_logs_enabled" {
+  description = "Specifies whether the trail is delivered to CloudWatch Logs."
+  default     = true
+}
+
 variable "cloudtrail_cloudwatch_logs_group_name" {
   description = "The name of CloudWatch Logs group to which CloudTrail events are delivered."
   default     = "cloudtrail-multi-region"
@@ -258,8 +263,13 @@ variable "cloudtrail_name" {
   default     = "cloudtrail-multi-region"
 }
 
+variable "cloudtrail_sns_topic_enabled" {
+  description = "Specifies whether the trail is delivered to a SNS topic."
+  default     = true
+}
+
 variable "cloudtrail_sns_topic_name" {
-  description = "The name of the sns topic to link to the trail."
+  description = "The name of the SNS topic to link to the trail."
   default     = "cloudtrail-multi-region-sns-topic"
 }
 


### PR DESCRIPTION
Because we have a very AWS Lambda heavy workload, delivery to a Cloudwatch Logs generates a lot of costs. We don't need the logs, because the central S3 is enough. This PR makes both Cloudwatch Logs and SNS delivery optional (with the default remaining the same).