### PR TITLE
fix: prevent AWS Config to fire alarms

### DIFF
--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "recorder_publish_policy" {
   }
 
   statement {
-    actions   = ["s3:PutObject"]
+    actions   = ["s3:PutObject", "s3:PutObjectACl"]
     resources = ["${local.audit_log_bucket_arn}/config/AWSLogs/${var.aws_account_id}/*"]
 
     condition {


### PR DESCRIPTION
PubObjectAcl permission is required when AWS Config accesses the writability check file.