### PR TITLE
specify type for variable 'tag' in modules/secure-bucket and modules/cloudtrail-baseline

### DIFF
--- a/modules/cloudtrail-baseline/variables.tf
+++ b/modules/cloudtrail-baseline/variables.tf
@@ -77,6 +77,7 @@ variable "s3_object_level_logging_buckets" {
 
 variable "tags" {
   description = "Specifies object tags key and value. This applies to all resources created by this module."
+  type        = map(string)
   default = {
     "Terraform" = true
   }

--- a/modules/secure-bucket/variables.tf
+++ b/modules/secure-bucket/variables.tf
@@ -25,7 +25,7 @@ variable "enabled" {
 variable "tags" {
   description = "Specifies object tags key and value. This applies to all resources created by this module."
   type        = map(string)
-  default     = {
+  default = {
     "Terraform" = true
   }
 }

--- a/modules/secure-bucket/variables.tf
+++ b/modules/secure-bucket/variables.tf
@@ -21,7 +21,8 @@ variable "enabled" {
 
 variable "tags" {
   description = "Specifies object tags key and value. This applies to all resources created by this module."
-  default = {
+  type        = map(string)
+  default     = {
     "Terraform" = true
   }
 }

--- a/modules/secure-bucket/variables.tf
+++ b/modules/secure-bucket/variables.tf
@@ -6,16 +6,19 @@ variable "log_bucket_name" {
 
 variable "lifecycle_glacier_transition_days" {
   description = "The number of days after object creation when the object is archived into Glacier."
+  type        = number
   default     = 90
 }
 
 variable "force_destroy" {
-  description = " A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
+  description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
+  type        = bool
   default     = false
 }
 
 variable "enabled" {
   description = "A boolean that indicates this module is enabled. Resources are not created if it is set to false."
+  type        = bool
   default     = true
 }
 


### PR DESCRIPTION
This pull request fixes an issue (for me at least) with terraform 0.13.4 whereby terraform will refuse to create buckets as it is wrongly interpreting the tag variable (even with the default):

```
Error: Incorrect attribute value type

  on main.tf line 51, in resource "aws_s3_bucket" "access_log":
  51:   tags = var.tags
    |----------------
    | var.tags is "{\"Terraform\":true}"

Inappropriate value for attribute "tags": map of string required.
```

Two commits, the first (a28e9a3) fixes this bug, the second (162d6e4) adds types to the other vars and fixes a leading whitespace.