### PR TITLE
fix: edge case when not logging to cloudwatch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ module "cloudtrail_baseline" {
 module "alarm_baseline" {
   source = "./modules/alarm-baseline"
 
-  enabled                   = local.is_cloudtrail_enabled
+  enabled                   = local.is_cloudtrail_enabled && var.cloudtrail_cloudwatch_logs_enabled
   alarm_namespace           = var.alarm_namespace
   cloudtrail_log_group_name = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group : ""
   sns_topic_name            = var.alarm_sns_topic_name

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ module "alarm_baseline" {
 
   enabled                   = local.is_cloudtrail_enabled
   alarm_namespace           = var.alarm_namespace
-  cloudtrail_log_group_name = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group.name : ""
+  cloudtrail_log_group_name = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group : ""
   sns_topic_name            = var.alarm_sns_topic_name
 
   tags = var.tags

--- a/modules/cloudtrail-baseline/outputs.tf
+++ b/modules/cloudtrail-baseline/outputs.tf
@@ -20,5 +20,5 @@ output "log_delivery_iam_role" {
 
 output "log_group" {
   description = "The CloudWatch Logs log group which stores CloudTrail events."
-  value       = var.cloudwatch_logs_enabled && var.enabled ? aws_cloudwatch_log_group.cloudtrail_events[0] : null
+  value       = var.cloudwatch_logs_enabled && var.enabled ? aws_cloudwatch_log_group.cloudtrail_events[0].name : null
 }


### PR DESCRIPTION

Fixes: 
```
Error: Attempt to get attribute from null value

  on .terraform/modules/security/main.tf line 70, in module "alarm_baseline":
  70:   cloudtrail_log_group_name = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group.name : ""
    |----------------
    | module.cloudtrail_baseline.log_group is null
 ```
 
 Module:
 ```hcl-terraform
 module "security" {
  source = "nozaq/secure-baseline/aws"
  account_type = "individual"
  aws_account_id = data.aws_caller_identity.current.account_id
  #master_account_id = data.terraform_remote_state.master.outputs.account_id # Future
  audit_log_bucket_name = module.logs-edge.id 
  use_external_audit_log_bucket = true
  cloudtrail_s3_key_prefix = ""
  vpc_flow_logs_s3_key_prefix = ""
  config_s3_bucket_key_prefix = ""
  config_delivery_frequency = "TwentyFour_Hours"
  cloudtrail_cloudwatch_logs_enabled = false

  securityhub_enable_aws_foundational_standard = true
  securityhub_enable_cis_standard = true
  securityhub_enable_pci_dss_standard = false

  create_password_policy = false
  create_manager_role = true
  create_master_role = true
  create_support_role = false
  support_iam_role_principal_arns = []

  region = var.region
  target_regions = [
    var.region,
    "us-east-1", # edge
    ]

  #tags = local.workspace["tags"]

  providers = {
    aws = aws.edge
    aws.ap-northeast-1 = aws.ap-northeast-1
    aws.ap-northeast-2 = aws.ap-northeast-2
    aws.ap-northeast-3 = aws.ap-northeast-3
    aws.ap-south-1 = aws.ap-south-1
    aws.ap-southeast-1 = aws.ap-southeast-1
    aws.ap-southeast-2 = aws.ap-southeast-2
    aws.ca-central-1 = aws.ca-central-1
    aws.eu-central-1 = aws.eu-central-1
    aws.eu-north-1 = aws.eu-north-1
    aws.eu-west-1 = aws.eu-west-1
    aws.eu-west-2 = aws.eu-west-2
    aws.eu-west-3 = aws.eu-west-3
    aws.sa-east-1 = aws.sa-east-1
    aws.us-east-1 = aws.us-east-1
    aws.us-east-2 = aws.us-east-2
    aws.us-west-1 = aws.us-west-1
    aws.us-west-2 = aws.us-west-2
  }
}
```