### PR TITLE
Enable access analyzer in organization example

### DIFF
--- a/examples/organization/master/main.tf
+++ b/examples/organization/master/main.tf
@@ -13,6 +13,7 @@ resource "aws_iam_user" "admin" {
 
 resource "aws_organizations_organization" "org" {
   aws_service_access_principals = [
+    "access-analyzer.amazonaws.com",
     "cloudtrail.amazonaws.com",
     "config.amazonaws.com",
   ]


### PR DESCRIPTION
In order to setup an organization analyzer, `access-analyzer.amazonaws.com` must be added as a trusted service principal.  Otherwise, setup fails with error noted in #166.

(ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/accessanalyzer_analyzer)