### PR TITLE
Add flag to allow recording global resource config in all regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This module is composed of several submodules and each of which can be used inde
 | config\_aggregator\_name | The name of the organizational AWS Config Configuration Aggregator. | `string` | `"organization-aggregator"` | no |
 | config\_aggregator\_name\_prefix | The prefix of the name for the IAM role attached to the organizational AWS Config Configuration Aggregator. | `string` | `"config-for-organization-role"` | no |
 | config\_delivery\_frequency | The frequency which AWS Config sends a snapshot into the S3 bucket. | `string` | `"One_Hour"` | no |
+| config\_global\_resources\_all\_regions | Whether to record global resources in all regions. If false, only the default region (specified in var.region) will record global resources. | bool | `false` | no |
 | config\_iam\_role\_name | The name of the IAM Role which AWS Config will use. | `string` | `"Config-Recorder"` | no |
 | config\_iam\_role\_policy\_name | The name of the IAM Role Policy which AWS Config will use. | `string` | `"Config-Recorder-Policy"` | no |
 | config\_s3\_bucket\_key\_prefix | The prefix used when writing AWS Config snapshots into the S3 bucket. | `string` | `"config"` | no |

--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -94,7 +94,7 @@ module "config_baseline_ap-northeast-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "ap-northeast-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-1"
   tags                          = var.tags
 }
 
@@ -111,7 +111,7 @@ module "config_baseline_ap-northeast-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "ap-northeast-2"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-2"
   tags                          = var.tags
 }
 
@@ -128,7 +128,7 @@ module "config_baseline_ap-south-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "ap-south-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-south-1"
   tags                          = var.tags
 }
 
@@ -145,7 +145,7 @@ module "config_baseline_ap-southeast-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "ap-southeast-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-1"
   tags                          = var.tags
 }
 
@@ -162,7 +162,7 @@ module "config_baseline_ap-southeast-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "ap-southeast-2"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-2"
   tags                          = var.tags
 }
 
@@ -179,7 +179,7 @@ module "config_baseline_ca-central-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "ca-central-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ca-central-1"
   tags                          = var.tags
 }
 
@@ -196,7 +196,7 @@ module "config_baseline_eu-central-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "eu-central-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-central-1"
   tags                          = var.tags
 }
 
@@ -213,7 +213,7 @@ module "config_baseline_eu-north-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "eu-north-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-north-1"
   tags                          = var.tags
 }
 
@@ -230,7 +230,7 @@ module "config_baseline_eu-west-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "eu-west-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-1"
   tags                          = var.tags
 }
 
@@ -247,7 +247,7 @@ module "config_baseline_eu-west-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "eu-west-2"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-2"
   tags                          = var.tags
 }
 
@@ -264,7 +264,7 @@ module "config_baseline_eu-west-3" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "eu-west-3"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-3"
   tags                          = var.tags
 }
 
@@ -281,7 +281,7 @@ module "config_baseline_sa-east-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "sa-east-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "sa-east-1"
   tags                          = var.tags
 }
 
@@ -298,7 +298,7 @@ module "config_baseline_us-east-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "us-east-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-1"
   tags                          = var.tags
 }
 
@@ -315,7 +315,7 @@ module "config_baseline_us-east-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "us-east-2"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-2"
   tags                          = var.tags
 }
 
@@ -332,7 +332,7 @@ module "config_baseline_us-west-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "us-west-1"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-1"
   tags                          = var.tags
 }
 
@@ -349,7 +349,7 @@ module "config_baseline_us-west-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  include_global_resource_types = var.region == "us-west-2"
+  include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-2"
   tags                          = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -269,6 +269,11 @@ variable "config_aggregator_name_prefix" {
   default     = "config-for-organization-role"
 }
 
+variable "config_global_resources_all_regions" {
+  description = "Record global resources in all regions. If false, only default region will record global resources."
+  default     = false
+}
+
 # --------------------------------------------------------------------------------------------------
 # Variables for cloudtrail-baseline module.
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The default configuration for SecurityHub and related AWS/CIS/PCI benchmarks expect to find global resource recording in each region - and all get rather unhappy if it's not there.  SecurityHub, specifically, complains that AWS Config is not setup properly.  

Guidance from AWS on this:
* They enable global recording in all regions with their provided tooling: https://github.com/awslabs/aws-securityhub-multiaccount-scripts
* Note this as a best practice here (item 2): https://aws.amazon.com/blogs/security/nine-aws-security-hub-best-practices/
* Recommend conditionally disabling several controls in non-primary regions (see https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-prereq-config.html#config-resource-recording) if only recording global resources in a single region.  

This PR adds a flag to allow turning on global recording in all regions. Default is currently false to avoid introducing a bunch of unexpected updates, but it might in fact be better to default true.

