### PR TITLE
feat: add vpc_enable variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ This module is composed of several submodules and each of which can be used inde
 | tags | Specifies object tags key and value. This applies to all resources created by this module. | `map` | `{}` | no |
 | target\_regions | A list of regions to set up with this module. | `list` | <pre>[<br>  "ap-northeast-1",<br>  "ap-northeast-2",<br>  "ap-south-1",<br>  "ap-southeast-1",<br>  "ap-southeast-2",<br>  "ca-central-1",<br>  "eu-central-1",<br>  "eu-north-1",<br>  "eu-west-1",<br>  "eu-west-2",<br>  "eu-west-3",<br>  "sa-east-1",<br>  "us-east-1",<br>  "us-east-2",<br>  "us-west-1",<br>  "us-west-2"<br>]</pre> | no |
 | use\_external\_audit\_log\_bucket | A boolean that indicates whether the specific audit log bucket already exists. Create a new S3 bucket if it is set to false. | `bool` | `false` | no |
+| vpc\_enable | The boolean flag whether to enable VPC module | `bool` | `true` | no |
 | vpc\_enable\_flow\_logs | The boolean flag whether to enable VPC Flow Logs in default VPCs | `bool` | `true` | no |
 | vpc\_flow\_logs\_destination\_type | The type of the logging destination. Valid values: cloud-watch-logs, s3 | `string` | `"cloud-watch-logs"` | no |
 | vpc\_flow\_logs\_log\_group\_name | The name of CloudWatch Logs group to which VPC Flow Logs are delivered. | `string` | `"default-vpc-flow-logs"` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,11 @@ variable "allow_users_to_change_password" {
 # --------------------------------------------------------------------------------------------------
 # Variables for vpc-baseline module.
 # --------------------------------------------------------------------------------------------------
+variable "vpc_enable" {
+  description = "Boolean whether the VPC baseline module should be enabled"
+  default     = true
+}
+
 variable "vpc_iam_role_name" {
   description = "The name of the IAM Role which VPC Flow Logs will use."
   default     = "VPC-Flow-Logs-Publisher"

--- a/vpc_baselines.tf
+++ b/vpc_baselines.tf
@@ -1,4 +1,5 @@
 locals {
+  is_enabled = var.vpc_enable
   is_cw_logs = var.vpc_enable_flow_logs && (var.vpc_flow_logs_destination_type == "cloud-watch-logs")
   is_s3      = var.vpc_enable_flow_logs && (var.vpc_flow_logs_destination_type == "s3")
   flow_logs_s3_arn = local.is_s3 ? (
@@ -11,7 +12,7 @@ locals {
 # Reference: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html#flow-logs-iam
 # --------------------------------------------------------------------------------------------------
 data "aws_iam_policy_document" "flow_logs_publisher_assume_role_policy" {
-  count = var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
+  count = local.is_enabled && var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
 
   statement {
     principals {
@@ -23,7 +24,7 @@ data "aws_iam_policy_document" "flow_logs_publisher_assume_role_policy" {
 }
 
 resource "aws_iam_role" "flow_logs_publisher" {
-  count = var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
+  count = local.is_enabled && var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
 
   name               = var.vpc_iam_role_name
   assume_role_policy = data.aws_iam_policy_document.flow_logs_publisher_assume_role_policy[0].json
@@ -32,7 +33,7 @@ resource "aws_iam_role" "flow_logs_publisher" {
 }
 
 data "aws_iam_policy_document" "flow_logs_publish_policy" {
-  count = var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
+  count = local.is_enabled && var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
 
   statement {
     actions = [
@@ -47,7 +48,7 @@ data "aws_iam_policy_document" "flow_logs_publish_policy" {
 }
 
 resource "aws_iam_role_policy" "flow_logs_publish_policy" {
-  count = var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
+  count = local.is_enabled && var.vpc_enable_flow_logs && local.is_cw_logs ? 1 : 0
 
   name = var.vpc_iam_role_policy_name
   role = aws_iam_role.flow_logs_publisher[0].id
@@ -67,7 +68,7 @@ module "vpc_baseline_ap-northeast-1" {
     aws = aws.ap-northeast-1
   }
 
-  enabled                     = contains(var.target_regions, "ap-northeast-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "ap-northeast-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -87,7 +88,7 @@ module "vpc_baseline_ap-northeast-2" {
     aws = aws.ap-northeast-2
   }
 
-  enabled                     = contains(var.target_regions, "ap-northeast-2")
+  enabled                     = local.is_enabled && contains(var.target_regions, "ap-northeast-2")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -107,7 +108,7 @@ module "vpc_baseline_ap-south-1" {
     aws = aws.ap-south-1
   }
 
-  enabled                     = contains(var.target_regions, "ap-south-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "ap-south-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -127,7 +128,7 @@ module "vpc_baseline_ap-southeast-1" {
     aws = aws.ap-southeast-1
   }
 
-  enabled                     = contains(var.target_regions, "ap-southeast-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "ap-southeast-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -147,7 +148,7 @@ module "vpc_baseline_ap-southeast-2" {
     aws = aws.ap-southeast-2
   }
 
-  enabled                     = contains(var.target_regions, "ap-southeast-2")
+  enabled                     = local.is_enabled && contains(var.target_regions, "ap-southeast-2")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -167,7 +168,7 @@ module "vpc_baseline_ca-central-1" {
     aws = aws.ca-central-1
   }
 
-  enabled                     = contains(var.target_regions, "ca-central-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "ca-central-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -187,7 +188,7 @@ module "vpc_baseline_eu-central-1" {
     aws = aws.eu-central-1
   }
 
-  enabled                     = contains(var.target_regions, "eu-central-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "eu-central-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -207,7 +208,7 @@ module "vpc_baseline_eu-north-1" {
     aws = aws.eu-north-1
   }
 
-  enabled                     = contains(var.target_regions, "eu-north-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "eu-north-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -227,7 +228,7 @@ module "vpc_baseline_eu-west-1" {
     aws = aws.eu-west-1
   }
 
-  enabled                     = contains(var.target_regions, "eu-west-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "eu-west-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -247,7 +248,7 @@ module "vpc_baseline_eu-west-2" {
     aws = aws.eu-west-2
   }
 
-  enabled                     = contains(var.target_regions, "eu-west-2")
+  enabled                     = local.is_enabled && contains(var.target_regions, "eu-west-2")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -267,7 +268,7 @@ module "vpc_baseline_eu-west-3" {
     aws = aws.eu-west-3
   }
 
-  enabled                     = contains(var.target_regions, "eu-west-3")
+  enabled                     = local.is_enabled && contains(var.target_regions, "eu-west-3")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -287,7 +288,7 @@ module "vpc_baseline_sa-east-1" {
     aws = aws.sa-east-1
   }
 
-  enabled                     = contains(var.target_regions, "sa-east-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "sa-east-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -307,7 +308,7 @@ module "vpc_baseline_us-east-1" {
     aws = aws.us-east-1
   }
 
-  enabled                     = contains(var.target_regions, "us-east-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "us-east-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -327,7 +328,7 @@ module "vpc_baseline_us-east-2" {
     aws = aws.us-east-2
   }
 
-  enabled                     = contains(var.target_regions, "us-east-2")
+  enabled                     = local.is_enabled && contains(var.target_regions, "us-east-2")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -347,7 +348,7 @@ module "vpc_baseline_us-west-1" {
     aws = aws.us-west-1
   }
 
-  enabled                     = contains(var.target_regions, "us-west-1")
+  enabled                     = local.is_enabled && contains(var.target_regions, "us-west-1")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name
@@ -367,7 +368,7 @@ module "vpc_baseline_us-west-2" {
     aws = aws.us-west-2
   }
 
-  enabled                     = contains(var.target_regions, "us-west-2")
+  enabled                     = local.is_enabled && contains(var.target_regions, "us-west-2")
   enable_flow_logs            = var.vpc_enable_flow_logs
   flow_logs_destination_type  = var.vpc_flow_logs_destination_type
   flow_logs_log_group_name    = var.vpc_flow_logs_log_group_name


### PR DESCRIPTION
Hello, 
I added a variable that allows to disable vpc-baseline submodule. We use the default VPC and we can't just wipe out the route table and NACL.

Also regarding the [aws documentation](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-2.9) it should be enough to enable the flow log only for packet rejects and the traffic_type is hardcoded to ALL in the submodule.

Thank you for publishing this module, it really helped a lot with setting up the alarms required by CIS benchmark.