### PR TITLE
fix: allow alarm variables to be set at top level module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,10 +65,25 @@ module "cloudtrail_baseline" {
 module "alarm_baseline" {
   source = "./modules/alarm-baseline"
 
-  enabled                   = local.is_cloudtrail_enabled && var.cloudtrail_cloudwatch_logs_enabled
-  alarm_namespace           = var.alarm_namespace
-  cloudtrail_log_group_name = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group : ""
-  sns_topic_name            = var.alarm_sns_topic_name
+  enabled                          = local.is_cloudtrail_enabled && var.cloudtrail_cloudwatch_logs_enabled
+  unauthorized_api_calls_enabled   = var.unauthorized_api_calls_enabled
+  no_mfa_console_signin_enabled    = var.no_mfa_console_signin_enabled
+  root_usage_enabled               = var.root_usage_enabled
+  iam_changes_enabled              = var.iam_changes_enabled
+  cloudtrail_cfg_changes_enabled   = var.cloudtrail_cfg_changes_enabled
+  console_signin_failures_enabled  = var.console_signin_failures_enabled
+  disable_or_delete_cmk_enabled    = var.disable_or_delete_cmk_enabled
+  s3_bucket_policy_changes_enabled = var.s3_bucket_policy_changes_enabled
+  aws_config_changes_enabled       = var.aws_config_changes_enabled
+  security_group_changes_enabled   = var.security_group_changes_enabled
+  nacl_changes_enabled             = var.nacl_changes_enabled
+  network_gw_changes_enabled       = var.network_gw_changes_enabled
+  route_table_changes_enabled      = var.route_table_changes_enabled
+  vpc_changes_enabled              = var.vpc_changes_enabled
+  organizations_changes_enabled    = var.organizations_changes_enabled
+  alarm_namespace                  = var.alarm_namespace
+  cloudtrail_log_group_name        = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group : ""
+  sns_topic_name                   = var.alarm_sns_topic_name
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -347,6 +347,80 @@ variable "alarm_sns_topic_name" {
   description = "The name of the SNS Topic which will be notified when any alarm is performed."
   default     = "CISAlarm"
 }
+variable "unauthorized_api_calls_enabled" {
+  description = "The boolean flag whether the unauthorized_api_calls alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "no_mfa_console_signin_enabled" {
+  description = "The boolean flag whether the no_mfa_console_signin alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "root_usage_enabled" {
+  description = "The boolean flag whether the root_usage alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "iam_changes_enabled" {
+  description = "The boolean flag whether the iam_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "cloudtrail_cfg_changes_enabled" {
+  description = "The boolean flag whether the cloudtrail_cfg_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "console_signin_failures_enabled" {
+  description = "The boolean flag whether the console_signin_failures alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "disable_or_delete_cmk_enabled" {
+  description = "The boolean flag whether the disable_or_delete_cmk alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "s3_bucket_policy_changes_enabled" {
+  description = "The boolean flag whether the s3_bucket_policy_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "aws_config_changes_enabled" {
+  description = "The boolean flag whether the aws_config_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "security_group_changes_enabled" {
+  description = "The boolean flag whether the security_group_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "nacl_changes_enabled" {
+  description = "The boolean flag whether the nacl_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "network_gw_changes_enabled" {
+  description = "The boolean flag whether the network_gw_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "route_table_changes_enabled" {
+  description = "The boolean flag whether the route_table_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "vpc_changes_enabled" {
+  description = "The boolean flag whether the vpc_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
+
+variable "organizations_changes_enabled" {
+  description = "The boolean flag whether the organizations_changes alarm is enabled or not. No resources are created when set to false."
+  default     = true
+}
 
 # --------------------------------------------------------------------------------------------------
 # Variables for guardduty-baseline module.


### PR DESCRIPTION
This PR will enable the use of the changes in https://github.com/nozaq/terraform-aws-secure-baseline/pull/164 (control individual alarms).

I forgot to add them to the original PR. Apologies.