### PR TITLE
feat: add cloudtrail insight selector type specification

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ module "cloudtrail_baseline" {
   aws_account_id                    = var.aws_account_id
   cloudtrail_depends_on             = [aws_s3_bucket_policy.audit_log]
   cloudtrail_name                   = var.cloudtrail_name
+  cloudtrail_insight_selector_type  = var.cloudtrail_insight_selector_type
   cloudtrail_sns_topic_enabled      = var.cloudtrail_sns_topic_enabled
   cloudtrail_sns_topic_name         = var.cloudtrail_sns_topic_name
   cloudwatch_logs_enabled           = var.cloudtrail_cloudwatch_logs_enabled

--- a/modules/cloudtrail-baseline/main.tf
+++ b/modules/cloudtrail-baseline/main.tf
@@ -261,6 +261,10 @@ resource "aws_cloudtrail" "global" {
     }
   }
 
+  insight_selector {
+    insight_type = var.cloudtrail_insight_selector_type
+  }
+
   tags = var.tags
 
   depends_on = [var.cloudtrail_depends_on]

--- a/modules/cloudtrail-baseline/variables.tf
+++ b/modules/cloudtrail-baseline/variables.tf
@@ -12,6 +12,11 @@ variable "cloudtrail_name" {
   default     = "cloudtrail-multi-region"
 }
 
+variable "cloudtrail_insight_selector_type" {
+  description = "The type of insight selector for identifying unusual operational activity"
+  default     = null
+}
+
 variable "cloudtrail_sns_topic_enabled" {
   description = "Specifies whether the trail is delivered to a SNS topic."
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -314,6 +314,11 @@ variable "cloudtrail_name" {
   default     = "cloudtrail-multi-region"
 }
 
+variable "cloudtrail_insight_selector_type" {
+  description = "The type of insight selector for identifying unusual operational activity"
+  default     = null
+}
+
 variable "cloudtrail_sns_topic_enabled" {
   description = "Specifies whether the trail is delivered to a SNS topic."
   default     = true


### PR DESCRIPTION
Hello
I added variable `cloudtrail_insight_selector_type` where you can set insight_selector type to `ApiCallRateInsight` which is so far the only value that is accepted as is documented in [official terraform documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail#insight_selector). 

Default value is set to `null`.