### PR TITLE
feat: Add functionality to manually enable/disable guardduty-baseline module

### DIFF
--- a/guardduty_baselines.tf
+++ b/guardduty_baselines.tf
@@ -15,7 +15,7 @@ module "guardduty_baseline_ap-northeast-1" {
     aws = aws.ap-northeast-1
   }
 
-  enabled                      = contains(var.target_regions, "ap-northeast-1")
+  enabled                      = contains(var.target_regions, "ap-northeast-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -32,7 +32,7 @@ module "guardduty_baseline_ap-northeast-2" {
     aws = aws.ap-northeast-2
   }
 
-  enabled                      = contains(var.target_regions, "ap-northeast-2")
+  enabled                      = contains(var.target_regions, "ap-northeast-2") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -49,7 +49,7 @@ module "guardduty_baseline_ap-northeast-3" {
     aws = aws.ap-northeast-3
   }
 
-  enabled                      = contains(var.target_regions, "ap-northeast-3")
+  enabled                      = contains(var.target_regions, "ap-northeast-3") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -66,7 +66,7 @@ module "guardduty_baseline_ap-south-1" {
     aws = aws.ap-south-1
   }
 
-  enabled                      = contains(var.target_regions, "ap-south-1")
+  enabled                      = contains(var.target_regions, "ap-south-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -83,7 +83,7 @@ module "guardduty_baseline_ap-southeast-1" {
     aws = aws.ap-southeast-1
   }
 
-  enabled                      = contains(var.target_regions, "ap-southeast-1")
+  enabled                      = contains(var.target_regions, "ap-southeast-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -100,7 +100,7 @@ module "guardduty_baseline_ap-southeast-2" {
     aws = aws.ap-southeast-2
   }
 
-  enabled                      = contains(var.target_regions, "ap-southeast-2")
+  enabled                      = contains(var.target_regions, "ap-southeast-2") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -117,7 +117,7 @@ module "guardduty_baseline_ca-central-1" {
     aws = aws.ca-central-1
   }
 
-  enabled                      = contains(var.target_regions, "ca-central-1")
+  enabled                      = contains(var.target_regions, "ca-central-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -134,7 +134,7 @@ module "guardduty_baseline_eu-central-1" {
     aws = aws.eu-central-1
   }
 
-  enabled                      = contains(var.target_regions, "eu-central-1")
+  enabled                      = contains(var.target_regions, "eu-central-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -151,7 +151,7 @@ module "guardduty_baseline_eu-north-1" {
     aws = aws.eu-north-1
   }
 
-  enabled                      = contains(var.target_regions, "eu-north-1")
+  enabled                      = contains(var.target_regions, "eu-north-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -168,7 +168,7 @@ module "guardduty_baseline_eu-west-1" {
     aws = aws.eu-west-1
   }
 
-  enabled                      = contains(var.target_regions, "eu-west-1")
+  enabled                      = contains(var.target_regions, "eu-west-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -185,7 +185,7 @@ module "guardduty_baseline_eu-west-2" {
     aws = aws.eu-west-2
   }
 
-  enabled                      = contains(var.target_regions, "eu-west-2")
+  enabled                      = contains(var.target_regions, "eu-west-2") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -202,7 +202,7 @@ module "guardduty_baseline_eu-west-3" {
     aws = aws.eu-west-3
   }
 
-  enabled                      = contains(var.target_regions, "eu-west-3")
+  enabled                      = contains(var.target_regions, "eu-west-3") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -219,7 +219,7 @@ module "guardduty_baseline_sa-east-1" {
     aws = aws.sa-east-1
   }
 
-  enabled                      = contains(var.target_regions, "sa-east-1")
+  enabled                      = contains(var.target_regions, "sa-east-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -236,7 +236,7 @@ module "guardduty_baseline_us-east-1" {
     aws = aws.us-east-1
   }
 
-  enabled                      = contains(var.target_regions, "us-east-1")
+  enabled                      = contains(var.target_regions, "us-east-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -253,7 +253,7 @@ module "guardduty_baseline_us-east-2" {
     aws = aws.us-east-2
   }
 
-  enabled                      = contains(var.target_regions, "us-east-2")
+  enabled                      = contains(var.target_regions, "us-east-2") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -270,7 +270,7 @@ module "guardduty_baseline_us-west-1" {
     aws = aws.us-west-1
   }
 
-  enabled                      = contains(var.target_regions, "us-west-1")
+  enabled                      = contains(var.target_regions, "us-west-1") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message
@@ -287,7 +287,7 @@ module "guardduty_baseline_us-west-2" {
     aws = aws.us-west-2
   }
 
-  enabled                      = contains(var.target_regions, "us-west-2")
+  enabled                      = contains(var.target_regions, "us-west-2") && var.guardduty_enabled
   disable_email_notification   = var.guardduty_disable_email_notification
   finding_publishing_frequency = var.guardduty_finding_publishing_frequency
   invitation_message           = var.guardduty_invitation_message

--- a/variables.tf
+++ b/variables.tf
@@ -190,6 +190,11 @@ variable "allow_users_to_change_password" {
 # --------------------------------------------------------------------------------------------------
 # Variables for vpc-baseline module.
 # --------------------------------------------------------------------------------------------------
+variable "vpc_enable" {
+  description = "Boolean whether the VPC baseline module should be enabled"
+  default     = true
+}
+
 variable "vpc_iam_role_name" {
   description = "The name of the IAM Role which VPC Flow Logs will use."
   default     = "VPC-Flow-Logs-Publisher"
@@ -248,6 +253,11 @@ variable "config_iam_role_name" {
 variable "config_iam_role_policy_name" {
   description = "The name of the IAM Role Policy which AWS Config will use."
   default     = "Config-Recorder-Policy"
+}
+
+variable "config_sns_topic_kms_master_key_id" {
+  description = "To enable SNS Topic encryption enter value with the ID or an alias (eg. alias/aws/sns) of a custom master KMS key that is used for encryption"
+  default     = null
 }
 
 variable "config_s3_bucket_key_prefix" {
@@ -339,6 +349,11 @@ variable "cloudtrail_s3_object_level_logging_buckets" {
 # Variables for alarm-baseline module.
 # --------------------------------------------------------------------------------------------------
 
+variable "alarm_sns_topic_kms_master_key_id" {
+  description = "To enable SNS Topic encryption enter value with the ID or an alias (eg. alias/aws/sns) of a custom master KMS key that is used for encryption"
+  default     = null
+}
+
 variable "alarm_namespace" {
   description = "The namespace in which all alarms are set up."
   default     = "CISBenchmark"
@@ -352,6 +367,11 @@ variable "alarm_sns_topic_name" {
 # --------------------------------------------------------------------------------------------------
 # Variables for guardduty-baseline module.
 # --------------------------------------------------------------------------------------------------
+variable "guardduty_enabled" {
+  description = "Boolean whether the guardduty-baseline module is enabled or disabled"
+  default     = true
+}
+
 variable "guardduty_disable_email_notification" {
   description = "Boolean whether an email notification is sent to the accounts."
   default     = false


### PR DESCRIPTION
In this pull request I added functionality to manualy enable or disable usage of a guardduty-baseline module. When calling **terraform-aws-secure-baseline** module set **guardduty_enabled** argument to `true`/`false`.

Default value of parameter **guardduty_enabled** is set to `true`.