### PR TITLE
feat: add kms_master_key_id to alarm baseline and config-baseline module

### DIFF
--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -95,6 +95,7 @@ module "config_baseline_ap-northeast-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-1"
   tags                          = var.tags
 }
@@ -112,6 +113,7 @@ module "config_baseline_ap-northeast-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-2"
   tags                          = var.tags
 }
@@ -129,6 +131,7 @@ module "config_baseline_ap-northeast-3" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-3"
   tags                          = var.tags
 }
@@ -146,6 +149,7 @@ module "config_baseline_ap-south-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-south-1"
   tags                          = var.tags
 }
@@ -163,6 +167,7 @@ module "config_baseline_ap-southeast-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-1"
   tags                          = var.tags
 }
@@ -180,6 +185,7 @@ module "config_baseline_ap-southeast-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-2"
   tags                          = var.tags
 }
@@ -197,6 +203,7 @@ module "config_baseline_ca-central-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ca-central-1"
   tags                          = var.tags
 }
@@ -214,6 +221,7 @@ module "config_baseline_eu-central-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-central-1"
   tags                          = var.tags
 }
@@ -231,6 +239,7 @@ module "config_baseline_eu-north-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-north-1"
   tags                          = var.tags
 }
@@ -248,6 +257,7 @@ module "config_baseline_eu-west-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-1"
   tags                          = var.tags
 }
@@ -265,6 +275,7 @@ module "config_baseline_eu-west-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-2"
   tags                          = var.tags
 }
@@ -282,6 +293,7 @@ module "config_baseline_eu-west-3" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-3"
   tags                          = var.tags
 }
@@ -299,6 +311,7 @@ module "config_baseline_sa-east-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "sa-east-1"
   tags                          = var.tags
 }
@@ -316,6 +329,7 @@ module "config_baseline_us-east-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-1"
   tags                          = var.tags
 }
@@ -333,6 +347,7 @@ module "config_baseline_us-east-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-2"
   tags                          = var.tags
 }
@@ -350,6 +365,7 @@ module "config_baseline_us-west-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-1"
   tags                          = var.tags
 }
@@ -367,6 +383,7 @@ module "config_baseline_us-west-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
+  kms_master_key_id             = var.config_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-2"
   tags                          = var.tags
 }

--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -95,7 +95,7 @@ module "config_baseline_ap-northeast-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-1"
   tags                          = var.tags
 }
@@ -113,7 +113,7 @@ module "config_baseline_ap-northeast-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-2"
   tags                          = var.tags
 }
@@ -131,7 +131,7 @@ module "config_baseline_ap-northeast-3" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-3"
   tags                          = var.tags
 }
@@ -149,7 +149,7 @@ module "config_baseline_ap-south-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-south-1"
   tags                          = var.tags
 }
@@ -167,7 +167,7 @@ module "config_baseline_ap-southeast-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-1"
   tags                          = var.tags
 }
@@ -185,7 +185,7 @@ module "config_baseline_ap-southeast-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-2"
   tags                          = var.tags
 }
@@ -203,7 +203,7 @@ module "config_baseline_ca-central-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ca-central-1"
   tags                          = var.tags
 }
@@ -221,7 +221,7 @@ module "config_baseline_eu-central-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-central-1"
   tags                          = var.tags
 }
@@ -239,7 +239,7 @@ module "config_baseline_eu-north-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-north-1"
   tags                          = var.tags
 }
@@ -257,7 +257,7 @@ module "config_baseline_eu-west-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-1"
   tags                          = var.tags
 }
@@ -275,7 +275,7 @@ module "config_baseline_eu-west-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-2"
   tags                          = var.tags
 }
@@ -293,7 +293,7 @@ module "config_baseline_eu-west-3" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-3"
   tags                          = var.tags
 }
@@ -311,7 +311,7 @@ module "config_baseline_sa-east-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "sa-east-1"
   tags                          = var.tags
 }
@@ -329,7 +329,7 @@ module "config_baseline_us-east-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-1"
   tags                          = var.tags
 }
@@ -347,7 +347,7 @@ module "config_baseline_us-east-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-2"
   tags                          = var.tags
 }
@@ -365,7 +365,7 @@ module "config_baseline_us-west-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-1"
   tags                          = var.tags
 }
@@ -383,7 +383,7 @@ module "config_baseline_us-west-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  kms_master_key_id             = var.config_kms_master_key_id
+  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-2"
   tags                          = var.tags
 }

--- a/config_baselines.tf
+++ b/config_baselines.tf
@@ -95,7 +95,7 @@ module "config_baseline_ap-northeast-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-1"
   tags                          = var.tags
 }
@@ -113,7 +113,7 @@ module "config_baseline_ap-northeast-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-2"
   tags                          = var.tags
 }
@@ -131,7 +131,7 @@ module "config_baseline_ap-northeast-3" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-northeast-3"
   tags                          = var.tags
 }
@@ -149,7 +149,7 @@ module "config_baseline_ap-south-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-south-1"
   tags                          = var.tags
 }
@@ -167,7 +167,7 @@ module "config_baseline_ap-southeast-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-1"
   tags                          = var.tags
 }
@@ -185,7 +185,7 @@ module "config_baseline_ap-southeast-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ap-southeast-2"
   tags                          = var.tags
 }
@@ -203,7 +203,7 @@ module "config_baseline_ca-central-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "ca-central-1"
   tags                          = var.tags
 }
@@ -221,7 +221,7 @@ module "config_baseline_eu-central-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-central-1"
   tags                          = var.tags
 }
@@ -239,7 +239,7 @@ module "config_baseline_eu-north-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-north-1"
   tags                          = var.tags
 }
@@ -257,7 +257,7 @@ module "config_baseline_eu-west-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-1"
   tags                          = var.tags
 }
@@ -275,7 +275,7 @@ module "config_baseline_eu-west-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-2"
   tags                          = var.tags
 }
@@ -293,7 +293,7 @@ module "config_baseline_eu-west-3" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "eu-west-3"
   tags                          = var.tags
 }
@@ -311,7 +311,7 @@ module "config_baseline_sa-east-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "sa-east-1"
   tags                          = var.tags
 }
@@ -329,7 +329,7 @@ module "config_baseline_us-east-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-1"
   tags                          = var.tags
 }
@@ -347,7 +347,7 @@ module "config_baseline_us-east-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-east-2"
   tags                          = var.tags
 }
@@ -365,7 +365,7 @@ module "config_baseline_us-west-1" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-1"
   tags                          = var.tags
 }
@@ -383,7 +383,7 @@ module "config_baseline_us-west-2" {
   s3_key_prefix                 = var.config_s3_bucket_key_prefix
   delivery_frequency            = var.config_delivery_frequency
   sns_topic_name                = var.config_sns_topic_name
-  sns_topic_kms_master_key_id             = var.config_sns_topic_kms_master_key_id
+  sns_topic_kms_master_key_id   = var.config_sns_topic_kms_master_key_id
   include_global_resource_types = var.config_global_resources_all_regions ? true : var.region == "us-west-2"
   tags                          = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ module "alarm_baseline" {
   alarm_namespace           = var.alarm_namespace
   cloudtrail_log_group_name = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group : ""
   sns_topic_name            = var.alarm_sns_topic_name
-  kms_master_key_id         = var.alarm_kms_master_key_id
+  sns_topic_kms_master_key_id = var.alarm_sns_topic_kms_master_key_id
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -65,10 +65,10 @@ module "cloudtrail_baseline" {
 module "alarm_baseline" {
   source = "./modules/alarm-baseline"
 
-  enabled                   = local.is_cloudtrail_enabled && var.cloudtrail_cloudwatch_logs_enabled
-  alarm_namespace           = var.alarm_namespace
-  cloudtrail_log_group_name = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group : ""
-  sns_topic_name            = var.alarm_sns_topic_name
+  enabled                     = local.is_cloudtrail_enabled && var.cloudtrail_cloudwatch_logs_enabled
+  alarm_namespace             = var.alarm_namespace
+  cloudtrail_log_group_name   = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group : ""
+  sns_topic_name              = var.alarm_sns_topic_name
   sns_topic_kms_master_key_id = var.alarm_sns_topic_kms_master_key_id
 
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ module "alarm_baseline" {
   alarm_namespace           = var.alarm_namespace
   cloudtrail_log_group_name = local.is_cloudtrail_enabled ? module.cloudtrail_baseline.log_group : ""
   sns_topic_name            = var.alarm_sns_topic_name
+  kms_master_key_id         = var.alarm_kms_master_key_id
 
   tags = var.tags
 }

--- a/modules/alarm-baseline/main.tf
+++ b/modules/alarm-baseline/main.tf
@@ -5,7 +5,7 @@
 resource "aws_sns_topic" "alarms" {
   count = var.enabled ? 1 : 0
 
-  kms_master_key_id = var.kms_master_key_id
+  kms_master_key_id = var.sns_topic_kms_master_key_id
 
   name = var.sns_topic_name
 

--- a/modules/alarm-baseline/main.tf
+++ b/modules/alarm-baseline/main.tf
@@ -5,6 +5,8 @@
 resource "aws_sns_topic" "alarms" {
   count = var.enabled ? 1 : 0
 
+  kms_master_key_id = var.kms_master_key_id
+
   name = var.sns_topic_name
 
   tags = var.tags

--- a/modules/alarm-baseline/variables.tf
+++ b/modules/alarm-baseline/variables.tf
@@ -87,6 +87,11 @@ variable "cloudtrail_log_group_name" {
   description = "The name of the CloudWatch Logs group to which CloudTrail events are delivered."
 }
 
+variable "kms_master_key_id" {
+  description = "ID of kms master key"
+  default     = "kms-master-key-id"
+}
+
 variable "sns_topic_name" {
   description = "The name of the SNS Topic which will be notified when any alarm is performed."
   default     = "CISAlarm"

--- a/modules/alarm-baseline/variables.tf
+++ b/modules/alarm-baseline/variables.tf
@@ -87,9 +87,9 @@ variable "cloudtrail_log_group_name" {
   description = "The name of the CloudWatch Logs group to which CloudTrail events are delivered."
 }
 
-variable "kms_master_key_id" {
-  description = "ID of kms master key"
-  default     = "kms-master-key-id"
+variable "sns_topic_kms_master_key_id" {
+  description = "To enable SNS Topic encryption enter value with the ID or an alias (eg. alias/aws/sns) of a custom master KMS key that is used for encryption"
+  default     = null
 }
 
 variable "sns_topic_name" {

--- a/modules/config-baseline/main.tf
+++ b/modules/config-baseline/main.tf
@@ -5,7 +5,7 @@
 resource "aws_sns_topic" "config" {
   count = var.enabled ? 1 : 0
 
-  kms_master_key_id = var.kms_master_key_id
+  kms_master_key_id = var.sns_topic_kms_master_key_id
 
   name = var.sns_topic_name
 

--- a/modules/config-baseline/main.tf
+++ b/modules/config-baseline/main.tf
@@ -5,6 +5,8 @@
 resource "aws_sns_topic" "config" {
   count = var.enabled ? 1 : 0
 
+  kms_master_key_id = var.kms_master_key_id
+
   name = var.sns_topic_name
 
   tags = var.tags

--- a/modules/config-baseline/variables.tf
+++ b/modules/config-baseline/variables.tf
@@ -7,6 +7,11 @@ variable "iam_role_arn" {
   description = "The ARN of the IAM Role which AWS Config will use."
 }
 
+variable "kms_master_key_id" {
+  description = "ID of kms master key"
+  default     = "MISSING"
+}
+
 variable "s3_bucket_name" {
   description = "The name of the S3 bucket which will store configuration snapshots."
 }

--- a/modules/config-baseline/variables.tf
+++ b/modules/config-baseline/variables.tf
@@ -7,9 +7,9 @@ variable "iam_role_arn" {
   description = "The ARN of the IAM Role which AWS Config will use."
 }
 
-variable "kms_master_key_id" {
-  description = "ID of kms master key"
-  default     = "MISSING"
+variable "sns_topic_kms_master_key_id" {
+  description = "To enable SNS Topic encryption enter value with the ID or an alias (eg. alias/aws/sns) of a custom master KMS key that is used for encryption"
+  default     = null
 }
 
 variable "s3_bucket_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -250,9 +250,9 @@ variable "config_iam_role_policy_name" {
   default     = "Config-Recorder-Policy"
 }
 
-variable "config_kms_master_key_id" {
-  description = "ID of kms master key"
-  default     = "kms-master-key-id"
+variable "config_sns_topic_kms_master_key_id" {
+  description = "To enable SNS Topic encryption enter value with the ID or an alias (eg. alias/aws/sns) of a custom master KMS key that is used for encryption"
+  default     = null
 }
 
 variable "config_s3_bucket_key_prefix" {
@@ -344,9 +344,9 @@ variable "cloudtrail_s3_object_level_logging_buckets" {
 # Variables for alarm-baseline module.
 # --------------------------------------------------------------------------------------------------
 
-variable "alarm_kms_master_key_id" {
-  description = "ID of kms master key"
-  default     = "kms-master-key-id"
+variable "alarm_sns_topic_kms_master_key_id" {
+  description = "To enable SNS Topic encryption enter value with the ID or an alias (eg. alias/aws/sns) of a custom master KMS key that is used for encryption"
+  default     = null
 }
 
 variable "alarm_namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -250,6 +250,11 @@ variable "config_iam_role_policy_name" {
   default     = "Config-Recorder-Policy"
 }
 
+variable "config_kms_master_key_id" {
+  description = "ID of kms master key"
+  default     = "kms-master-key-id"
+}
+
 variable "config_s3_bucket_key_prefix" {
   description = "The prefix used when writing AWS Config snapshots into the S3 bucket."
   default     = "config"
@@ -338,6 +343,11 @@ variable "cloudtrail_s3_object_level_logging_buckets" {
 # --------------------------------------------------------------------------------------------------
 # Variables for alarm-baseline module.
 # --------------------------------------------------------------------------------------------------
+
+variable "alarm_kms_master_key_id" {
+  description = "ID of kms master key"
+  default     = "kms-master-key-id"
+}
 
 variable "alarm_namespace" {
   description = "The namespace in which all alarms are set up."


### PR DESCRIPTION
In this PR I added possibility to use **KMS key** for encryption of an **SNS Topics** used by modules `alarm-baseline` and `config-baseline`. 

Set **alarm_sns_topic_kms_master_key_id** parameter with value of either KMS key ID or it's Alias name.
Set **config_sns_topic_kms_master_key_id** parameter with value of either KMS key ID or it's Alias name.

Default values: 

**alarm_sns_topic_kms_master_key_id**  = `null`
**config_sns_topic_kms_master_key_id** = `null`