### PR TITLE
fix duplicate guard duty detector creation for member accounts

### DIFF
--- a/modules/guardduty-baseline/main.tf
+++ b/modules/guardduty-baseline/main.tf
@@ -2,8 +2,10 @@
 # Enables GuardDuty.
 # --------------------------------------------------------------------------------------------------
 
+# Used for master account setup
+
 resource "aws_guardduty_detector" "default" {
-  count = var.enabled ? 1 : 0
+  count = var.enabled && var.master_account_id == "" ? 1 : 0
 
   enable                       = true
   finding_publishing_frequency = var.finding_publishing_frequency
@@ -12,7 +14,7 @@ resource "aws_guardduty_detector" "default" {
 }
 
 resource "aws_guardduty_member" "members" {
-  count = var.enabled ? length(var.member_accounts) : 0
+  count = var.enabled && var.master_account_id == "" ? length(var.member_accounts) : 0
 
   detector_id = aws_guardduty_detector.default[0].id
   invite      = true
@@ -23,9 +25,15 @@ resource "aws_guardduty_member" "members" {
   invitation_message         = var.invitation_message
 }
 
+# Used for member account setup
+
 resource "aws_guardduty_invite_accepter" "master" {
   count = var.enabled && var.master_account_id != "" ? 1 : 0
 
-  detector_id       = aws_guardduty_detector.default[0].id
+  detector_id       = data.aws_guardduty_detector.default[0].id # aws_guardduty_detector.default[0].id
   master_account_id = var.master_account_id
+}
+
+data "aws_guardduty_detector" "default" {
+  count = var.enabled && var.master_account_id != "" ? 1 : 0
 }

--- a/modules/guardduty-baseline/outputs.tf
+++ b/modules/guardduty-baseline/outputs.tf
@@ -1,4 +1,4 @@
 output "guardduty_detector" {
   description = "The GuardDuty detector."
-  value       = var.enabled ? aws_guardduty_detector.default[0] : null
+  value       = var.enabled ? try(aws_guardduty_detector.default[0], data.aws_guardduty_detector.default[0]) : null
 }


### PR DESCRIPTION
when using the [organization setup](https://github.com/nozaq/terraform-aws-secure-baseline/tree/master/examples/organization) member accounts were attempting to create a guard duty detector. those are created automatically when you join the master org with guard duty enabled.

closes: #199 