### PR TITLE
guardduty: use data_source / accepter model when configuring a member account

### DIFF
--- a/modules/guardduty-baseline/outputs.tf
+++ b/modules/guardduty-baseline/outputs.tf
@@ -1,4 +1,4 @@
 output "guardduty_detector" {
   description = "The GuardDuty detector."
-  value       = var.enabled ? aws_guardduty_detector.default[0] : null
+  value       = var.enabled ? try(aws_guardduty_detector.default[0], data.aws_guardduty_detector.default[0]) : null
 }


### PR DESCRIPTION
closes: #199

create a detector when `var.master_account_id != ""`

else search for a detector and accept invite