### PR TITLE
[vpc-baseline] Apply default subnet changes to existing subnets

### DIFF
--- a/modules/vpc-baseline/main.tf
+++ b/modules/vpc-baseline/main.tf
@@ -6,6 +6,23 @@ locals {
 data "aws_availability_zones" "all" {
 }
 
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = var.enabled ? [aws_default_vpc.default[0].id] : []
+  }
+
+  filter {
+    name   = "default-for-az"
+    values = [true]
+  }
+}
+
+data "aws_subnet" "default" {
+  for_each = toset(data.aws_subnets.default.ids)
+  id       = each.value
+}
+
 # --------------------------------------------------------------------------------------------------
 # Enable VPC Flow Logs for the default VPC.
 # --------------------------------------------------------------------------------------------------
@@ -45,9 +62,9 @@ resource "aws_default_vpc" "default" {
 }
 
 resource "aws_default_subnet" "default" {
-  count = var.enabled ? length(data.aws_availability_zones.all.names) : 0
+  for_each = data.aws_subnet.default
 
-  availability_zone       = data.aws_availability_zones.all.names[count.index]
+  availability_zone       = each.value.availability_zone
   map_public_ip_on_launch = false
 
   tags = merge(

--- a/modules/vpc-baseline/versions.tf
+++ b/modules/vpc-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.50.0"
+      version = ">= 3.55.0"
     }
   }
 }


### PR DESCRIPTION
The `aws_default_subnet` resources will only be created for existing VPC default subnets. This will fix `Default subnet not found` errors when one or multiple default subnets do not exist in the VPC. Fixes #198

Notes: 

* This requires bumping the aws provider minimum version to 3.55.0 to add support for [`aws_subnets` data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets). 
* Since this change uses `for_each` instead of `count`, the `aws_default_subnet` resources will be recreated using subnet ids instead of indexes. 