### PR TITLE
fix: remove `aws_default_vpc` dependency

### DIFF
--- a/modules/vpc-baseline/README.md
+++ b/modules/vpc-baseline/README.md
@@ -12,7 +12,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.55.0 |
 
 ## Providers
 
@@ -36,6 +36,8 @@ No modules.
 | [aws_default_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_vpc) | resource |
 | [aws_flow_log.default_vpc_flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_availability_zones.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_subnet.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnets.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 
 ## Inputs
 

--- a/modules/vpc-baseline/main.tf
+++ b/modules/vpc-baseline/main.tf
@@ -8,11 +8,6 @@ data "aws_availability_zones" "all" {
 
 data "aws_subnets" "default" {
   filter {
-    name   = "vpc-id"
-    values = var.enabled ? [aws_default_vpc.default[0].id] : []
-  }
-
-  filter {
     name   = "default-for-az"
     values = [true]
   }


### PR DESCRIPTION
To keep `aws_subnets.default` being a known value before apply.

Refs: https://www.terraform.io/docs/language/meta-arguments/for_each.html#limitations-on-values-used-in-for_each