### PR TITLE
fix: require AWS provider v4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ This module is composed of several submodules and each of which can be used inde
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/examples/external-bucket/main.tf
+++ b/examples/external-bucket/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/examples/organization/master/main.tf
+++ b/examples/organization/master/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/examples/organization/member/main.tf
+++ b/examples/organization/member/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/examples/select-region/main.tf
+++ b/examples/select-region/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
 
       # A provider alias should be passed for each AWS region.
       # Reference: https://docs.aws.amazon.com/general/latest/gr/rande.html

--- a/modules/alarm-baseline/README.md
+++ b/modules/alarm-baseline/README.md
@@ -8,13 +8,13 @@ Set up CloudWatch alarms to notify you when critical changes happen in your AWS 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/alarm-baseline/versions.tf
+++ b/modules/alarm-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/analyzer-baseline/README.md
+++ b/modules/analyzer-baseline/README.md
@@ -10,13 +10,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/analyzer-baseline/versions.tf
+++ b/modules/analyzer-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/cloudtrail-baseline/README.md
+++ b/modules/cloudtrail-baseline/README.md
@@ -8,13 +8,13 @@ Enable CloudTrail in all regions and deliver events to CloudWatch Logs. CloudTra
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/cloudtrail-baseline/versions.tf
+++ b/modules/cloudtrail-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/config-baseline/README.md
+++ b/modules/config-baseline/README.md
@@ -8,13 +8,13 @@ Enable AWS Config in all regions to automatically take configuration snapshots.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/config-baseline/versions.tf
+++ b/modules/config-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/ebs-baseline/README.md
+++ b/modules/ebs-baseline/README.md
@@ -10,13 +10,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/ebs-baseline/versions.tf
+++ b/modules/ebs-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/guardduty-baseline/README.md
+++ b/modules/guardduty-baseline/README.md
@@ -8,13 +8,13 @@ Enable GuardDuty in all regions.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/guardduty-baseline/versions.tf
+++ b/modules/guardduty-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/iam-baseline/README.md
+++ b/modules/iam-baseline/README.md
@@ -11,13 +11,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/iam-baseline/versions.tf
+++ b/modules/iam-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/s3-baseline/README.md
+++ b/modules/s3-baseline/README.md
@@ -10,13 +10,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/s3-baseline/versions.tf
+++ b/modules/s3-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/secure-bucket/README.md
+++ b/modules/secure-bucket/README.md
@@ -8,13 +8,13 @@ Creates a S3 bucket with access logging enabled.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/secure-bucket/versions.tf
+++ b/modules/secure-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/securityhub-baseline/README.md
+++ b/modules/securityhub-baseline/README.md
@@ -13,13 +13,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/securityhub-baseline/versions.tf
+++ b/modules/securityhub-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/modules/vpc-baseline/README.md
+++ b/modules/vpc-baseline/README.md
@@ -12,13 +12,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.2.0 |
 
 ## Inputs
 

--- a/modules/vpc-baseline/versions.tf
+++ b/modules/vpc-baseline/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/test/fixtures/simple_local/main.tf
+++ b/test/fixtures/simple_local/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }

--- a/test/fixtures/simple_registry/main.tf
+++ b/test/fixtures/simple_registry/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.1.0"
+      version = ">= 4.2.0"
     }
   }
 }


### PR DESCRIPTION
Updated the provider requiremenet to avoid the issue in AWS provider
v4.1.0 that the validation fails for some AWS regions.
