### PR TITLE
Fix logging policies

### DIFF
--- a/modules/alarm-baseline/main.tf
+++ b/modules/alarm-baseline/main.tf
@@ -43,7 +43,7 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
   count = var.unauthorized_api_calls_enabled ? 1 : 0
 
   name           = "UnauthorizedAPICalls"
-  pattern        = "{(($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\")) && (($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") && ($.eventName!=\"HeadBucket\"))}"
+  pattern        = "{(($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\"))}"
   log_group_name = var.cloudtrail_log_group_name
 
   metric_transformation {


### PR DESCRIPTION
Related to: https://github.com/nozaq/terraform-aws-secure-baseline/issues/233

It seems that the CIS control in Security Hub has the following metric fail, using the CIS AWS Foundations 3.1 (Edit: Or rather 1.2.0) Benchmark.

```
Ensure a log metric filter and alarm exist for unauthorized API calls
[CloudWatch.2] Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for unauthorized API calls. Remediation instructions 
```

This specifically seems to be the case since it is not only selecting from logging anymore, but also tagging.

I.e. I'd get errors like:
```
•errorCode: AccessDenied
 •eventName: GetResources
 •eventSource: tagging.amazonaws.com
```

The control error states: CLOUDTRAIL_METRIC_FILTER_NOT_VALID
The multi-Region CloudTrail does not have a valid metric filter


Suggesting to revert/adjust the pattern/metric filter to match with what the CIS benchmark requests:

```
[CloudWatch.2] Ensure a log metric filter and alarm exist for unauthorized API calls

To run this check, Security Hub uses custom logic to perform the exact audit steps prescribed for control 3.1 in the CIS AWS Foundations Benchmark v1.2. This control fails if the exact metric filters prescribed by CIS are not used. Additional fields or terms cannot be added to the metric filters.
```


Adjusted the pattern/metric filter from:
```
  pattern        = "{(($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\")) && (($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") && ($.eventName!=\"HeadBucket\"))}"
```

to:
```
  pattern        = "{(($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\"))}"
```

Additional information:
https://docs.aws.amazon.com/securityhub/latest/userguide/cloudwatch-controls.html#cloudwatch-2
