### PR TITLE
feat: use dynamical expressions for UnauthorizedAPICalls

### DIFF
--- a/modules/alarm-baseline/main.tf
+++ b/modules/alarm-baseline/main.tf
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_log_metric_filter" "unauthorized_api_calls" {
   metric_transformation {
     name      = "UnauthorizedAPICalls"
     namespace = var.alarm_namespace
-    value     = "1"
+    value     = (var.metric_unauthorizedapicalls == true ? 2 : 1)
   }
 }
 

--- a/modules/alarm-baseline/variables.tf
+++ b/modules/alarm-baseline/variables.tf
@@ -124,3 +124,9 @@ variable "tags" {
     "Terraform" = "true"
   }
 }
+
+variable "metric_unauthorizedapicalls" {
+  description = "This is the value of the amount of UnauthorizedAPICalls"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
We're using a webhook that pushes an event to Slack whenever the `UnauthorizedAPICalls` is triggered. However, they're not unauthorized (after all, we are of course authorized to assume roles within our own AWS Organization). This results in spamming the channel when we're assuming roles in AWS. Changing this to a value of '2' may decrease this amount.